### PR TITLE
Milestone/errorcodes

### DIFF
--- a/source/Makefile.arm32_linux
+++ b/source/Makefile.arm32_linux
@@ -1,7 +1,7 @@
 # Project: exvm_arm32
 
 BIN      = bin/exvm_arm32
-CXXFLAGS = -O3 -Wall -W -march=native -fomit-frame-pointer -D_VM_HOST_OS=_VM_HOST_LINUX_I386 -D_VM_INTERPRETER=_VM_INTERPRETER_SWITCH_CASE
+CXXFLAGS = -O3 -Wall -W -march=native -fomit-frame-pointer -fno-exceptions -fexpensive-optimizations -D_VM_HOST_OS=_VM_HOST_LINUX_I386 -D_VM_INTERPRETER=_VM_INTERPRETER_SWITCH_CASE
 OBJ      = obj/arm32_linux/main.o \
            obj/arm32_linux/vm_program.o \
            obj/arm32_linux/machine.o \

--- a/source/Makefile.arm64_linux
+++ b/source/Makefile.arm64_linux
@@ -1,7 +1,7 @@
 # Project: exvm_arm64
 
 BIN      = bin/exvm_arm64
-CXXFLAGS = -O3 -Wall -W -march=native -fomit-frame-pointer -D_VM_HOST_OS=_VM_HOST_LINUX_X64 -D_VM_INTERPRETER=_VM_INTERPRETER_SWITCH_CASE
+CXXFLAGS = -O3 -Wall -W -march=native -fomit-frame-pointer -fno-exceptions -fexpensive-optimizations -D_VM_HOST_OS=_VM_HOST_LINUX_X64 -D_VM_INTERPRETER=_VM_INTERPRETER_SWITCH_CASE
 OBJ      = obj/arm64_linux/main.o \
            obj/arm64_linux/vmprogram.o \
            obj/arm64_linux/machine.o \

--- a/source/Makefile.os4
+++ b/source/Makefile.os4
@@ -1,7 +1,7 @@
 # Project: exvm_os4
 
 BIN      = bin/exvm_os4
-CXXFLAGS = -O3 -Wall -W -fomit-frame-pointer -D_VM_HOST_OS=_VM_HOST_AMIGAOS4_PPC -D_VM_INTERPRETER=_VM_INTERPRETER_SWITCH_CASE -D__USE_BASETYPE__
+CXXFLAGS = -O3 -Wall -W -fomit-frame-pointer -fno-exceptions -fexpensive-optimizations -D_VM_HOST_OS=_VM_HOST_AMIGAOS4_PPC -D_VM_INTERPRETER=_VM_INTERPRETER_SWITCH_CASE -D__USE_BASETYPE__
 OBJ      = obj/ppc_amigaos4/main.o \
            obj/ppc_amigaos4/vmprogram.o \
            obj/ppc_amigaos4/machine.o \

--- a/source/Makefile.os4-cross
+++ b/source/Makefile.os4-cross
@@ -1,7 +1,7 @@
 # Project: exvm_os4
 
 BIN      = bin/exvm_os4
-CXXFLAGS = -O3 -Wall -W -fomit-frame-pointer -fno-exceptions -D_VM_HOST_OS=_VM_HOST_AMIGAOS4_PPC -D_VM_INTERPRETER=_VM_INTERPRETER_SWITCH_CASE -D__USE_BASETYPE__
+CXXFLAGS = -O3 -Wall -W -fomit-frame-pointer -fno-exceptions -fexpensive-optimizations -D_VM_HOST_OS=_VM_HOST_AMIGAOS4_PPC -D_VM_INTERPRETER=_VM_INTERPRETER_SWITCH_CASE -D__USE_BASETYPE__
 OBJ      = obj/ppc_amigaos4/main.o \
            obj/ppc_amigaos4/vmprogram.o \
            obj/ppc_amigaos4/machine.o \

--- a/source/Makefile.x64_ft_linux
+++ b/source/Makefile.x64_ft_linux
@@ -1,7 +1,7 @@
 # Project: exvm_x64_ft
 
 BIN      = bin/exvm_x64_ft
-CXXFLAGS = -O3 -Wall -W -m64 -march=native -fomit-frame-pointer -D_VM_HOST_OS=_VM_HOST_LINUX_X64 -D_VM_INTERPRETER=_VM_INTERPRETER_FUNC_TABLE
+CXXFLAGS = -O3 -Wall -W -m64 -march=native -fomit-frame-pointer -fno-exceptions -fexpensive-optimizations -D_VM_HOST_OS=_VM_HOST_LINUX_X64 -D_VM_INTERPRETER=_VM_INTERPRETER_FUNC_TABLE
 OBJ      = obj/x64_ft_linux/main.o \
            obj/x64_ft_linux/vmprogram.o \
            obj/x64_ft_linux/machine.o \

--- a/source/Makefile.x64_linux
+++ b/source/Makefile.x64_linux
@@ -1,7 +1,7 @@
 # Project: exvm_x64
 
 BIN      = bin/exvm_x64
-CXXFLAGS = -O3 -Wall -W -m64 -march=native -fomit-frame-pointer -fexpensive-optimizations -D_VM_HOST_OS=_VM_HOST_LINUX_X64 -D_VM_INTERPRETER=_VM_INTERPRETER_SWITCH_CASE -D_GCC_USE_BUILTIN
+CXXFLAGS = -O3 -Wall -W -m64 -march=native -fomit-frame-pointer -fno-exceptions -fexpensive-optimizations -D_VM_HOST_OS=_VM_HOST_LINUX_X64 -D_VM_INTERPRETER=_VM_INTERPRETER_SWITCH_CASE -D_GCC_USE_BUILTIN
 OBJ      = obj/x64_linux/main.o \
            obj/x64_linux/vmprogram.o \
            obj/x64_linux/machine.o \

--- a/source/Makefile.x86_ft_linux
+++ b/source/Makefile.x86_ft_linux
@@ -1,7 +1,7 @@
 # Project: exvm_x86
 
 BIN      = bin/exvm_x86_ft
-CXXFLAGS = -O3 -Wall -W -m32 -march=native -mfpmath=sse -fomit-frame-pointer -D_VM_HOST_OS=_VM_HOST_LINUX_I386 -D_VM_INTERPRETER=_VM_INTERPRETER_FUNC_TABLE
+CXXFLAGS = -O3 -Wall -W -m32 -march=native -mfpmath=sse -fomit-frame-pointer -fno-exceptions -fexpensive-optimizations -D_VM_HOST_OS=_VM_HOST_LINUX_I386 -D_VM_INTERPRETER=_VM_INTERPRETER_FUNC_TABLE
 OBJ      = obj/x86_ft_linux/main.o \
            obj/x86_ft_linux/vmprogram.o \
            obj/x86_ft_linux/machine.o \

--- a/source/Makefile.x86_linux
+++ b/source/Makefile.x86_linux
@@ -1,7 +1,7 @@
 # Project: exvm_x86
 
 BIN      = bin/exvm_x86
-CXXFLAGS = -O3 -Wall -W -m32 -march=native -mfpmath=sse -fomit-frame-pointer -D_VM_HOST_OS=_VM_HOST_LINUX_I386 -D_VM_INTERPRETER=_VM_INTERPRETER_SWITCH_CASE
+CXXFLAGS = -O3 -Wall -W -m32 -march=native -mfpmath=sse -fomit-frame-pointer -fno-exceptions -fexpensive-optimizations -D_VM_HOST_OS=_VM_HOST_LINUX_I386 -D_VM_INTERPRETER=_VM_INTERPRETER_SWITCH_CASE
 OBJ      = obj/x86_linux/main.o \
            obj/x86_linux/vmprogram.o \
            obj/x86_linux/machine.o \

--- a/source/Makefile_Linker.x64_linux
+++ b/source/Makefile_Linker.x64_linux
@@ -1,7 +1,7 @@
 # Project: exvm_x64
 
 BIN      = bin/linker_x64
-CXXFLAGS = -O3 -Wall -W -m64 -march=native -fomit-frame-pointer -fexpensive-optimizations -D_VM_HOST_OS=_VM_HOST_LINUX_X64 -D_GCC_USE_BUILTIN
+CXXFLAGS = -O3 -Wall -W -m64 -march=native -fomit-frame-pointer -fno-exceptions -fexpensive-optimizations -D_VM_HOST_OS=_VM_HOST_LINUX_X64 -D_GCC_USE_BUILTIN
 OBJ      =  obj/x64_linux/vm_symbol.o \
             obj/x64_linux/vm_linker.o \
             obj/x64_linux/test_linker.o

--- a/source/Makefile_Symbol.x64_linux
+++ b/source/Makefile_Symbol.x64_linux
@@ -1,7 +1,7 @@
 # Project: exvm_x64
 
 BIN      = bin/symbol_x64
-CXXFLAGS = -O3 -Wall -W -m64 -march=native -fomit-frame-pointer -fexpensive-optimizations -D_VM_HOST_OS=_VM_HOST_LINUX_X64 -D_GCC_USE_BUILTIN
+CXXFLAGS = -O3 -Wall -W -m64 -march=native -fomit-frame-pointer -fno-exceptions -fexpensive-optimizations -D_VM_HOST_OS=_VM_HOST_LINUX_X64 -D_GCC_USE_BUILTIN
 OBJ      =  obj/x64_linux/vm_symbol.o \
             obj/x64_linux/test_symbol.o
 

--- a/source/Makefile_Symbol.x86_linux
+++ b/source/Makefile_Symbol.x86_linux
@@ -1,7 +1,7 @@
 # Project: exvm_x64
 
 BIN      = bin/symbol_x86
-CXXFLAGS = -O3 -Wall -W -m32 -march=native -fomit-frame-pointer -fexpensive-optimizations -D_VM_HOST_OS=_VM_HOST_LINUX_I386 -D_GCC_USE_BUILTIN
+CXXFLAGS = -O3 -Wall -W -m32 -march=native -fomit-frame-pointer -fno-exceptions -fexpensive-optimizations -D_VM_HOST_OS=_VM_HOST_LINUX_I386 -D_GCC_USE_BUILTIN
 OBJ      =  obj/x86_linux/vm_symbol.o \
             obj/x86_linux/test_symbol.o
 

--- a/source/allthethings.sh
+++ b/source/allthethings.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+make -f Makefile.x64_ft_linux clean
+make -f Makefile.x64_linux clean
+make -f Makefile.x86_ft_linux clean
+make -f Makefile.x86_linux clean
+make -f Makefile_Linker.x64_linux clean
+make -f Makefile_Symbol.x64_linux clean
+make -f Makefile_Symbol.x86_linux clean
+
+make -f Makefile.x64_ft_linux
+make -f Makefile.x64_linux
+make -f Makefile.x86_ft_linux
+make -f Makefile.x86_linux
+make -f Makefile_Linker.x64_linux
+make -f Makefile_Symbol.x64_linux
+make -f Makefile_Symbol.x86_linux

--- a/source/bin/.gitignore
+++ b/source/bin/.gitignore
@@ -1,3 +1,4 @@
 exvm_*
 symbol_*
+linker_*
 *.pgm

--- a/source/include/vm.hpp
+++ b/source/include/vm.hpp
@@ -37,17 +37,15 @@ namespace ExVM {
   // Host provided function call
   typedef void (*NativeCall)(Interpreter* vm);
 
-
-  // types:
-  // .s8, .s16, .s32, .s64 - signed integer
-  // .u8, .u16, .u32, .u64 - unsigned integer
-  // .f32, .f64            - float
-  // .i                    - any integer type
-  // .f                    - any float type
-  // .a                    - any arithmetic type
-
-  // .8, .16, .32, .64     - size only (untyped)
-  // .x                    - any operand
+  // Generic error codes
+  class Error {
+    public:
+      enum {
+        SUCCESS          = 0,
+        ILLEGAL_ARGUMENT = -1,
+        OUT_OF_MEMORY    = -2
+      };
+  };
 
   class VMDefs {
     public:

--- a/source/include/vm_linker.hpp
+++ b/source/include/vm_linker.hpp
@@ -32,6 +32,7 @@ namespace ExVM {
         MAX_SYMBOLS_NATIVE = 65536,
         MAX_SYMBOLS_CODE   = 65536,
         MAX_SYMBOLS_DATA   = 65536,
+        INI_SIZE           = 128
       };
 
     int registerNative(const char* symbol, NativeCall func);
@@ -44,10 +45,15 @@ namespace ExVM {
     private:
       struct Resolved;
 
-      SymbolEnumerator* native;
-      SymbolEnumerator* code;
-      SymbolEnumerator* data;
+      Resolved* native;
+      Resolved* code;
+      Resolved* data;
+
+      SymbolEnumerator* nativeEnumerator;
+      SymbolEnumerator* codeEnumerator;
+      SymbolEnumerator* dataEnumerator;
   };
 
 }
+
 #endif

--- a/source/include/vm_linker.hpp
+++ b/source/include/vm_linker.hpp
@@ -28,6 +28,13 @@ namespace ExVM {
   class Linker {
 
     public:
+      class Error : public ExVM::Error {
+        public:
+          enum {
+            ILLEGAL_SYMBOL_ADDRESS = -200,
+          };
+      };
+
       enum {
         MAX_SYMBOLS_NATIVE = 65536,
         MAX_SYMBOLS_CODE   = 65536,

--- a/source/include/vm_symbol.hpp
+++ b/source/include/vm_symbol.hpp
@@ -14,6 +14,7 @@
 
 #ifndef _VM_SYMBOL_HPP_
   #define _VM_SYMBOL_HPP_
+  #include "vm.hpp"
   #include "machine.hpp"
 
 namespace ExVM {
@@ -39,13 +40,15 @@ namespace ExVM {
   class SymbolEnumerator {
 
     public:
-      // Error enumerations
-      enum {
-        ERR_TABLE_FULL           = -1, // We have reached the maximum number of allowed symbol ID entries.
-        ERR_UNKNOWN_SYMBOL       = -2, // The requested symbol is not in the table.
-        ERR_DUPLICATE_SYMBOL     = -3, // An attempt to register the same symbol was made.
-        ERR_ILLEGAL_SYMBOL_CHAR  = -4, // A symbol contained an illegal character.
-        ERR_OUT_OF_MEMORY        = -5, // There was insufficient memory to allocate storage for symbol data.
+      class Error : public ExVM::Error {
+        public:
+          // Error enumerations specific to this component
+          enum {
+            ILLEGAL_SYMBOL_CHAR = ILLEGAL_ARGUMENT, // A symbol contained an illegal character.
+            TABLE_FULL          = -100,             // We have reached the maximum number of allowed symbol ID entries.
+            UNKNOWN_SYMBOL      = -101,             // The requested symbol is not in the table.
+            DUPLICATE_SYMBOL    = -102,             // An attempt to register the same symbol was made.
+          };
       };
 
       explicit SymbolEnumerator(uint32 maxSize);

--- a/source/test_symbol.cpp
+++ b/source/test_symbol.cpp
@@ -29,11 +29,11 @@ int main() {
     int         result; // the expected return value from add()
   } testData [] = {
     {"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz@_", 0 }, // Expect this to get ID 0
-    {"Breaking Bad", SymbolEnumerator::ERR_ILLEGAL_SYMBOL_CHAR },             // Expect this to fail
+    {"Breaking Bad", SymbolEnumerator::Error::ILLEGAL_SYMBOL_CHAR },          // Expect this to fail
     {"_totallyLegit123", 1 },                                                 // Expect this to get ID 1
-    {"_totallyLegit123", SymbolEnumerator::ERR_DUPLICATE_SYMBOL },            // Expect this to fail
+    {"_totallyLegit123", SymbolEnumerator::Error::DUPLICATE_SYMBOL },         // Expect this to fail
     {"_totallyLegit456", 2 },                                                 // Expect this to get ID 2
-    {"alasNoMoreRoom", SymbolEnumerator::ERR_TABLE_FULL }                     // Expect this to fail
+    {"alasNoMoreRoom", SymbolEnumerator::Error::TABLE_FULL }                  // Expect this to fail
   };
 
   // Now test the behaviour of add()

--- a/source/vm_linker.cpp
+++ b/source/vm_linker.cpp
@@ -39,9 +39,12 @@ struct Linker::Resolved {
 Linker::Linker() :
   native(0),
   code(0),
-  data(0)
+  data(0),
+  nativeEnumerator(0),
+  codeEnumerator(0),
+  dataEnumerator(0),
 {
-  
+
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/source/vm_linker.cpp
+++ b/source/vm_linker.cpp
@@ -42,7 +42,7 @@ Linker::Linker() :
   data(0),
   nativeEnumerator(0),
   codeEnumerator(0),
-  dataEnumerator(0),
+  dataEnumerator(0)
 {
 
 }

--- a/source/vm_symbol.cpp
+++ b/source/vm_symbol.cpp
@@ -126,7 +126,7 @@ int SymbolEnumerator::mapChar(int c) const {
     return 63;
   }
 
-  return ERR_ILLEGAL_SYMBOL_CHAR;
+  return Error::ILLEGAL_SYMBOL_CHAR;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -202,7 +202,7 @@ int SymbolEnumerator::get(const char* symbol) const {
 
   // If there is no rootNode, then no symbols have been added. Ipso facto, cannot be known!
   if (!rootNode) {
-    return ERR_UNKNOWN_SYMBOL;
+    return Error::UNKNOWN_SYMBOL;
   }
 
   PNode* primaryNode;
@@ -226,11 +226,11 @@ int SymbolEnumerator::get(const char* symbol) const {
     indexPrimary   = code & 3;
     indexSecondary = code >> 3;
     if (!primaryNode->children[indexPrimary]) {
-      return ERR_UNKNOWN_SYMBOL;
+      return Error::UNKNOWN_SYMBOL;
     }
     secondaryNode = primaryNode->children[indexPrimary];
     if (!secondaryNode->children[indexSecondary]) {
-      return ERR_UNKNOWN_SYMBOL;
+      return Error::UNKNOWN_SYMBOL;
     }
     primaryNode = secondaryNode->children[indexSecondary];
   }
@@ -250,10 +250,10 @@ int SymbolEnumerator::add(const char* symbol) {
   if (nextSymbolID == maxSymbols) {
 
 #ifdef VM_FULL_DEBUG
-    std::fprintf(stderr, "[ERR] Cannot add symbol %s, table limit of %u entries reached\n", symbol, maxSymbolID);
+    std::fprintf(stderr, "[ERR] Cannot add symbol %s, table limit of %u entries reached\n", symbol, maxSymbols);
 #endif
 
-    return ERR_TABLE_FULL;
+    return Error::TABLE_FULL;
   }
 
   // If we haven't allocated a symbol map yet, we better do it.
@@ -263,7 +263,7 @@ int SymbolEnumerator::add(const char* symbol) {
     std::fprintf(stderr, "[ERR] Could not allocate symbol map\n");
 #endif
 
-    return ERR_OUT_OF_MEMORY;
+    return Error::OUT_OF_MEMORY;
   }
 
   // If we haven't allocated the root of our trie yet, we better do it.
@@ -273,7 +273,7 @@ int SymbolEnumerator::add(const char* symbol) {
     std::fprintf(stderr, "[ERR] Could not allocate root node\n");
 #endif
 
-    return ERR_OUT_OF_MEMORY;
+    return Error::OUT_OF_MEMORY;
   }
 
   const char* pChar = symbol;
@@ -304,7 +304,7 @@ int SymbolEnumerator::add(const char* symbol) {
       !primaryNode->children[indexPrimary] &&
       !(primaryNode->children[indexPrimary] = allocSNode())
     ) {
-      return ERR_OUT_OF_MEMORY;
+      return Error::OUT_OF_MEMORY;
     }
     secondaryNode = primaryNode->children[indexPrimary];
 
@@ -313,7 +313,7 @@ int SymbolEnumerator::add(const char* symbol) {
       !secondaryNode->children[indexSecondary] &&
       !(secondaryNode->children[indexSecondary] = allocPNode())
     ) {
-      return ERR_OUT_OF_MEMORY;
+      return Error::OUT_OF_MEMORY;
     }
     primaryNode = secondaryNode->children[indexSecondary];
 
@@ -325,7 +325,7 @@ int SymbolEnumerator::add(const char* symbol) {
     symbolMap[symbolID] = symbol;
     return symbolID;
   } else {
-    return ERR_DUPLICATE_SYMBOL;
+    return Error::DUPLICATE_SYMBOL;
   }
 }
 


### PR DESCRIPTION
As much as we like C++ and exceptions, the quality of implementation across supported platforms, in particular with respect to thread safety, is too varied.

As we intend to ultimately migrate to C for the internal implementation, signalling of error conditions via more traditional enumerated error codes is appropriate. A C++ front can then, if desired, throw exceptions from these.