### PR TITLE
Tidied up debugging

### DIFF
--- a/source/Makefile.arm32_linux
+++ b/source/Makefile.arm32_linux
@@ -14,7 +14,8 @@ OBJ      = obj/arm32_linux/main.o \
            obj/arm32_linux/op_arithmetic.o \
            obj/arm32_linux/op_logic.o \
            obj/arm32_linux/vm_core.o \
-           obj/arm32_linux/op_normal_table.o
+           obj/arm32_linux/op_normal_table.o \
+           obj/arm32_linux/vm_debug.o
 
 $(BIN): $(OBJ) Makefile.arm32_linux
 	$(CXX) $(CXXFLAGS) $(OBJ) -o $(BIN)
@@ -58,6 +59,8 @@ obj/arm32_linux/vm_core.o: vm_core.cpp include/vm_core.hpp include/vm.hpp includ
 obj/arm32_linux/op_normal_table.o: op_normal_table.cpp include/vm_core.hpp include/vm.hpp include/machine.hpp
 	$(CXX) $(CXXFLAGS) -o $@ -c $<
 
+obj/arm32_linux/vm_debug.o: vm_debug.cpp include/vm.hpp include/machine.hpp
+	$(CXX) $(CXXFLAGS) -o $@ -c $<
 
 clean:
 	$(RM) $(TARGET) obj/arm32_linux/*.o *~ core

--- a/source/Makefile.arm64_linux
+++ b/source/Makefile.arm64_linux
@@ -14,7 +14,8 @@ OBJ      = obj/arm64_linux/main.o \
            obj/arm64_linux/op_arithmetic.o \
            obj/arm64_linux/op_logic.o \
            obj/arm64_linux/vm_core.o \
-           obj/arm64_linux/op_normal_table.o
+           obj/arm64_linux/op_normal_table.o \
+           obj/arm64_linux/vm_debug.o
 
 $(BIN): $(OBJ) Makefile.arm64_linux
 	$(CXX) $(CXXFLAGS) $(OBJ) -o $(BIN)
@@ -58,6 +59,8 @@ obj/arm64_linux/vm_core.o: vm_core.cpp include/vm_core.hpp include/vm.hpp includ
 obj/arm64_linux/op_normal_table.o: op_normal_table.cpp include/vm_core.hpp include/vm.hpp include/machine.hpp
 	$(CXX) $(CXXFLAGS) -o $@ -c $<
 
+obj/arm64_linux/vm_debug.o: vm_debug.cpp include/vm.hpp include/machine.hpp
+	$(CXX) $(CXXFLAGS) -o $@ -c $<
 
 clean:
 	$(RM) $(TARGET) obj/arm64_linux/*.o *~ core

--- a/source/Makefile.mos
+++ b/source/Makefile.mos
@@ -16,7 +16,8 @@ OBJ      = obj/ppc_morphos/main.o \
            obj/ppc_morphos/op_arithmetic.o \
            obj/ppc_morphos/op_logic.o \
            obj/ppc_morphos/vm_core.o \
-           obj/ppc_morphos/op_normal_table.o
+           obj/ppc_morphos/op_normal_table.o \
+           obj/ppc_morphos/vm_debug.o
 
 $(BIN): $(OBJ) Makefile.mos
 	$(CXX) $(CXXFLAGS) $(OBJ) -o $(BIN)
@@ -60,6 +61,8 @@ obj/ppc_morphos/vm_core.o: vm_core.cpp include/vm_core.hpp include/vm.hpp includ
 obj/ppc_morphos/op_normal_table.o: op_normal_table.cpp include/vm_core.hpp include/vm.hpp include/machine.hpp
 	$(CXX) $(CXXFLAGS) -o $@ -c $<
 
+obj/ppc_morphos/vm_debug.o: vm_debug.cpp include/vm.hpp include/machine.hpp
+	$(CXX) $(CXXFLAGS) -o $@ -c $<
 
 clean:
 	$(RM) $(TARGET) obj/ppc_morphos/*.o *~ core

--- a/source/Makefile.mos_ft
+++ b/source/Makefile.mos_ft
@@ -16,7 +16,8 @@ OBJ      = obj/ppc_morphos/main.o \
            obj/ppc_morphos/op_arithmetic.o \
            obj/ppc_morphos/op_logic.o \
            obj/ppc_morphos/vm_core.o \
-           obj/ppc_morphos/op_normal_table.o
+           obj/ppc_morphos/op_normal_table.o \
+           obj/ppc_morphos/vm_debug.o
 
 $(BIN): $(OBJ) Makefile.mos
 	$(CXX) $(CXXFLAGS) $(OBJ) -o $(BIN)
@@ -60,6 +61,8 @@ obj/ppc_morphos/vm_core.o: vm_core.cpp include/vm_core.hpp include/vm.hpp includ
 obj/ppc_morphos/op_normal_table.o: op_normal_table.cpp include/vm_core.hpp include/vm.hpp include/machine.hpp
 	$(CXX) $(CXXFLAGS) -o $@ -c $<
 
+obj/ppc_morphos/vm_debug.o: vm_debug.cpp include/vm.hpp include/machine.hpp
+	$(CXX) $(CXXFLAGS) -o $@ -c $<
 
 clean:
 	$(RM) $(TARGET) obj/ppc_morphos/*.o *~ core

--- a/source/Makefile.os4
+++ b/source/Makefile.os4
@@ -14,7 +14,8 @@ OBJ      = obj/ppc_amigaos4/main.o \
            obj/ppc_amigaos4/op_arithmetic.o \
            obj/ppc_amigaos4/op_logic.o \
            obj/ppc_amigaos4/vm_core.o \
-           obj/ppc_amigaos4/op_normal_table.o
+           obj/ppc_amigaos4/op_normal_table.o \
+           obj/ppc_amigaos4/vm_debug.o
 
 $(BIN): $(OBJ) Makefile.os4
 	$(CXX) $(CXXFLAGS) $(OBJ) -o $(BIN)
@@ -58,6 +59,8 @@ obj/ppc_amigaos4/vm_core.o: vm_core.cpp include/vm_core.hpp include/vm.hpp inclu
 obj/ppc_amigaos4/op_normal_table.o: op_normal_table.cpp include/vm_core.hpp include/vm.hpp include/machine.hpp
 	$(CXX) $(CXXFLAGS) -o $@ -c $<
 
+obj/ppc_amigaos4/vm_debug.o: vm_debug.cpp include/vm.hpp include/machine.hpp
+	$(CXX) $(CXXFLAGS) -o $@ -c $<
 
 clean:
 	$(RM) $(TARGET) obj/ppc_amigaos4/*.o *~ core

--- a/source/Makefile.os4-cross
+++ b/source/Makefile.os4-cross
@@ -14,7 +14,8 @@ OBJ      = obj/ppc_amigaos4/main.o \
            obj/ppc_amigaos4/op_arithmetic.o \
            obj/ppc_amigaos4/op_logic.o \
            obj/ppc_amigaos4/vm_core.o \
-           obj/ppc_amigaos4/op_normal_table.o
+           obj/ppc_amigaos4/op_normal_table.o \
+           obj/ppc_amigaos4/vm_debug.o
 
 CC      = ppc-amigaos-gcc
 CXX     = ppc-amigaos-g++
@@ -63,6 +64,8 @@ obj/ppc_amigaos4/vm_core.o: vm_core.cpp include/vm_core.hpp include/vm.hpp inclu
 obj/ppc_amigaos4/op_normal_table.o: op_normal_table.cpp include/vm_core.hpp include/vm.hpp include/machine.hpp
 	$(CXX) $(CXXFLAGS) -o $@ -c $<
 
+obj/ppc_amigaos4/vm_debug.o: vm_debug.cpp include/vm.hpp include/machine.hpp
+	$(CXX) $(CXXFLAGS) -o $@ -c $<
 
 clean:
 	$(RM) $(TARGET) obj/ppc_amigaos4/*.o *~ core

--- a/source/Makefile.x64_ft_linux
+++ b/source/Makefile.x64_ft_linux
@@ -14,7 +14,8 @@ OBJ      = obj/x64_ft_linux/main.o \
            obj/x64_ft_linux/op_arithmetic.o \
            obj/x64_ft_linux/op_logic.o \
            obj/x64_ft_linux/vm_core.o \
-           obj/x64_ft_linux/op_normal_table.o
+           obj/x64_ft_linux/op_normal_table.o \
+           obj/x64_ft_linux/vm_debug.o
 
 $(BIN): $(OBJ) Makefile.x64_ft_linux
 	$(CXX) $(CXXFLAGS) $(OBJ) -o $(BIN)
@@ -58,6 +59,8 @@ obj/x64_ft_linux/vm_core.o: vm_core.cpp include/vm_core.hpp include/vm.hpp inclu
 obj/x64_ft_linux/op_normal_table.o: op_normal_table.cpp include/vm_core.hpp include/vm.hpp include/machine.hpp
 	$(CXX) $(CXXFLAGS) -o $@ -c $<
 
+obj/x64_ft_linux/vm_debug.o: vm_debug.cpp include/vm.hpp include/machine.hpp
+	$(CXX) $(CXXFLAGS) -o $@ -c $<
 
 clean:
 	$(RM) $(TARGET) obj/x64_ft_linux/*.o *~ core

--- a/source/Makefile.x64_linux
+++ b/source/Makefile.x64_linux
@@ -14,7 +14,8 @@ OBJ      = obj/x64_linux/main.o \
            obj/x64_linux/op_arithmetic.o \
            obj/x64_linux/op_logic.o \
            obj/x64_linux/vm_core.o \
-           obj/x64_linux/op_normal_table.o
+           obj/x64_linux/op_normal_table.o \
+           obj/x64_linux/vm_debug.o
 
 $(BIN): $(OBJ) Makefile.x64_linux
 	$(CXX) $(CXXFLAGS) $(OBJ) -o $(BIN)
@@ -58,6 +59,10 @@ obj/x64_linux/vm_core.o: vm_core.cpp include/vm_core.hpp include/vm.hpp include/
 obj/x64_linux/op_normal_table.o: op_normal_table.cpp include/vm_core.hpp include/vm.hpp include/machine.hpp
 	$(CXX) $(CXXFLAGS) -o $@ -c $<
 
+obj/x64_linux/vm_debug.o: vm_debug.cpp include/vm.hpp include/machine.hpp
+	$(CXX) $(CXXFLAGS) -o $@ -c $<
+
 clean:
 	$(RM) $(TARGET) obj/x64_linux/*.o *~ core
+
 

--- a/source/Makefile.x86_ft_linux
+++ b/source/Makefile.x86_ft_linux
@@ -14,7 +14,8 @@ OBJ      = obj/x86_ft_linux/main.o \
            obj/x86_ft_linux/op_arithmetic.o \
            obj/x86_ft_linux/op_logic.o \
            obj/x86_ft_linux/vm_core.o \
-           obj/x86_ft_linux/op_normal_table.o
+           obj/x86_ft_linux/op_normal_table.o \
+           obj/x86_ft_linux/vm_debug.o
 
 $(BIN): $(OBJ) Makefile.x86_ft_linux
 	$(CXX) $(CXXFLAGS) $(OBJ) -o $(BIN)
@@ -56,6 +57,9 @@ obj/x86_ft_linux/vm_core.o: vm_core.cpp include/vm_core.hpp include/vm.hpp inclu
 	$(CXX) $(CXXFLAGS) -o $@ -c $<
 
 obj/x86_ft_linux/op_normal_table.o: op_normal_table.cpp include/vm_core.hpp include/vm.hpp include/machine.hpp
+	$(CXX) $(CXXFLAGS) -o $@ -c $<
+
+obj/x86_ft_linux/vm_debug.o: vm_debug.cpp include/vm.hpp include/machine.hpp
 	$(CXX) $(CXXFLAGS) -o $@ -c $<
 
 clean:

--- a/source/Makefile.x86_linux
+++ b/source/Makefile.x86_linux
@@ -14,7 +14,8 @@ OBJ      = obj/x86_linux/main.o \
            obj/x86_linux/op_arithmetic.o \
            obj/x86_linux/op_logic.o \
            obj/x86_linux/vm_core.o \
-           obj/x86_linux/op_normal_table.o
+           obj/x86_linux/op_normal_table.o \
+           obj/x86_linux/vm_debug.o
 
 $(BIN): $(OBJ) Makefile.x86_linux
 	$(CXX) $(CXXFLAGS) $(OBJ) -o $(BIN)
@@ -56,6 +57,9 @@ obj/x86_linux/vm_core.o: vm_core.cpp include/vm_core.hpp include/vm.hpp include/
 	$(CXX) $(CXXFLAGS) -o $@ -c $<
 
 obj/x86_linux/op_normal_table.o: op_normal_table.cpp include/vm_core.hpp include/vm.hpp include/machine.hpp
+	$(CXX) $(CXXFLAGS) -o $@ -c $<
+
+obj/x86_linux/vm_debug.o: vm_debug.cpp include/vm.hpp include/machine.hpp
 	$(CXX) $(CXXFLAGS) -o $@ -c $<
 
 clean:

--- a/source/Makefile_Linker.x64_linux
+++ b/source/Makefile_Linker.x64_linux
@@ -4,6 +4,7 @@ BIN      = bin/linker_x64
 CXXFLAGS = -O3 -Wall -W -m64 -march=native -fomit-frame-pointer -fno-exceptions -fexpensive-optimizations -D_VM_HOST_OS=_VM_HOST_LINUX_X64 -D_GCC_USE_BUILTIN
 OBJ      =  obj/x64_linux/vm_symbol.o \
             obj/x64_linux/vm_linker.o \
+            obj/x64_linux/vm_debug.o \
             obj/x64_linux/test_linker.o
 
 $(BIN): $(OBJ) Makefile_Linker.x64_linux
@@ -13,6 +14,9 @@ obj/x64_linux/vm_symbol.o: vm_symbol.cpp include/machine.hpp
 	$(CXX) $(CXXFLAGS) -o $@ -c $<
 
 obj/x64_linux/vm_linker.o: vm_linker.cpp include/machine.hpp
+	$(CXX) $(CXXFLAGS) -o $@ -c $<
+
+obj/x64_linux/vm_debug.o: vm_debug.cpp include/vm.hpp include/machine.hpp
 	$(CXX) $(CXXFLAGS) -o $@ -c $<
 
 obj/x64_linux/test_linker.o: test_linker.cpp include/machine.hpp

--- a/source/Makefile_Linker.x86_linux
+++ b/source/Makefile_Linker.x86_linux
@@ -1,0 +1,27 @@
+# Project: exvm_x64
+
+BIN      = bin/linker_x86
+CXXFLAGS = -O3 -Wall -W -m32 -march=native -fomit-frame-pointer -fno-exceptions -fexpensive-optimizations -D_VM_HOST_OS=_VM_HOST_LINUX_X64 -D_GCC_USE_BUILTIN
+OBJ      =  obj/x86_linux/vm_symbol.o \
+            obj/x86_linux/vm_linker.o \
+            obj/x86_linux/vm_debug.o \
+            obj/x86_linux/test_linker.o
+
+$(BIN): $(OBJ) Makefile_Linker.x86_linux
+	$(CXX) $(CXXFLAGS) $(OBJ) -o $(BIN)
+
+obj/x86_linux/vm_symbol.o: vm_symbol.cpp include/machine.hpp
+	$(CXX) $(CXXFLAGS) -o $@ -c $<
+
+obj/x86_linux/vm_linker.o: vm_linker.cpp include/machine.hpp
+	$(CXX) $(CXXFLAGS) -o $@ -c $<
+
+obj/x86_linux/vm_debug.o: vm_debug.cpp include/vm.hpp include/machine.hpp
+	$(CXX) $(CXXFLAGS) -o $@ -c $<
+
+obj/x86_linux/test_linker.o: test_linker.cpp include/machine.hpp
+	$(CXX) $(CXXFLAGS) -o $@ -c $<
+
+clean:
+	$(RM) $(TARGET) obj/x86_linux/*.o *~ core
+

--- a/source/Makefile_Symbol.x64_linux
+++ b/source/Makefile_Symbol.x64_linux
@@ -3,12 +3,16 @@
 BIN      = bin/symbol_x64
 CXXFLAGS = -O3 -Wall -W -m64 -march=native -fomit-frame-pointer -fno-exceptions -fexpensive-optimizations -D_VM_HOST_OS=_VM_HOST_LINUX_X64 -D_GCC_USE_BUILTIN
 OBJ      =  obj/x64_linux/vm_symbol.o \
+            obj/x64_linux/vm_debug.o \
             obj/x64_linux/test_symbol.o
 
 $(BIN): $(OBJ) Makefile_Symbol.x64_linux
 	$(CXX) $(CXXFLAGS) $(OBJ) -o $(BIN)
 
 obj/x64_linux/vm_symbol.o: vm_symbol.cpp include/machine.hpp
+	$(CXX) $(CXXFLAGS) -o $@ -c $<
+
+obj/x64_linux/vm_debug.o: vm_debug.cpp include/vm.hpp include/machine.hpp
 	$(CXX) $(CXXFLAGS) -o $@ -c $<
 
 obj/x64_linux/test_symbol.o: test_symbol.cpp include/machine.hpp

--- a/source/Makefile_Symbol.x86_linux
+++ b/source/Makefile_Symbol.x86_linux
@@ -3,12 +3,16 @@
 BIN      = bin/symbol_x86
 CXXFLAGS = -O3 -Wall -W -m32 -march=native -fomit-frame-pointer -fno-exceptions -fexpensive-optimizations -D_VM_HOST_OS=_VM_HOST_LINUX_I386 -D_GCC_USE_BUILTIN
 OBJ      =  obj/x86_linux/vm_symbol.o \
+            obj/x86_linux/vm_debug.o \
             obj/x86_linux/test_symbol.o
 
 $(BIN): $(OBJ) Makefile_Symbol.x86_linux
 	$(CXX) $(CXXFLAGS) $(OBJ) -o $(BIN)
 
 obj/x86_linux/vm_symbol.o: vm_symbol.cpp include/machine.hpp
+	$(CXX) $(CXXFLAGS) -o $@ -c $<
+
+obj/x86_linux/vm_debug.o: vm_debug.cpp include/vm.hpp include/machine.hpp
 	$(CXX) $(CXXFLAGS) -o $@ -c $<
 
 obj/x86_linux/test_symbol.o: test_symbol.cpp include/machine.hpp

--- a/source/allthethings.sh
+++ b/source/allthethings.sh
@@ -5,6 +5,7 @@ make -f Makefile.x64_linux clean
 make -f Makefile.x86_ft_linux clean
 make -f Makefile.x86_linux clean
 make -f Makefile_Linker.x64_linux clean
+make -f Makefile_Linker.x86_linux clean
 make -f Makefile_Symbol.x64_linux clean
 make -f Makefile_Symbol.x86_linux clean
 
@@ -13,5 +14,6 @@ make -f Makefile.x64_linux
 make -f Makefile.x86_ft_linux
 make -f Makefile.x86_linux
 make -f Makefile_Linker.x64_linux
+make -f Makefile_Linker.x86_linux
 make -f Makefile_Symbol.x64_linux
 make -f Makefile_Symbol.x86_linux

--- a/source/include/op_jump_impl.hpp
+++ b/source/include/op_jump_impl.hpp
@@ -27,10 +27,8 @@ _DEFINE_OP(BCALL8) {
   } else {
     vm->status = VMDefs::CALL_STACK_OVERFLOW;
 
-#ifdef VM_FULL_DEBUG
-    printf("Runtime error: call stack overflow\n");
-    vm->dump();
-#endif
+    debuglog(LOG_ERROR, "Call stack overflow in BCALL8");
+    dumpstate(vm);
 
     _THROW(-1)
   }
@@ -48,10 +46,8 @@ _DEFINE_OP(BCALL16) {
   } else {
     vm->status = VMDefs::CALL_STACK_OVERFLOW;
 
-#ifdef VM_FULL_DEBUG
-    printf("Runtime error: call stack overflow\n");
-    vm->dump();
-#endif
+    debuglog(LOG_ERROR, "Call stack overflow in BCALL16");
+    dumpstate(vm);
 
     _THROW(-1)
   }
@@ -66,10 +62,8 @@ _DEFINE_OP(CALL) {
   if (symbol >= vm->codeSymbolCount) {
     vm->status = VMDefs::UNKNOWN_CODE_SYMBOL;
 
-#ifdef VM_FULL_DEBUG
-    printf("Runtime error: Unknown code symbold : %d\n", (int)symbol);
-    vm->dump();
-#endif
+    debuglog(LOG_ERROR, "Unknown code symbold %d in CALL", (int)symbol);
+    dumpstate(vm);
 
     _THROW(-1)
   }
@@ -81,10 +75,8 @@ _DEFINE_OP(CALL) {
   } else {
     vm->status = VMDefs::CALL_STACK_OVERFLOW;
 
-#ifdef VM_FULL_DEBUG
-    printf("Runtime error: call stack overflow\n");
-    vm->dump();
-#endif
+    debuglog(LOG_ERROR, "Call stack overflow in CALL");
+    dumpstate(vm);
 
     _THROW(-1)
   }
@@ -98,10 +90,8 @@ _DEFINE_OP(CALLN) {
   if (symbol >= vm->nativeCodeSymbolCount) {
     vm->status = VMDefs::UNKNOWN_NATIVE_CODE_SYMBOL;
 
-#ifdef VM_FULL_DEBUG
-    printf("Runtime error: Unknown native code symbold : %d\n", (int)symbol);
-    vm->dump();
-#endif
+    debuglog(LOG_ERROR, "Unknown native code symbold %d in CALLN", (int)symbol);
+    dumpstate(vm);
 
     _THROW(-1)
   }
@@ -114,10 +104,8 @@ _DEFINE_OP(CALLN) {
   } else {
     vm->status = VMDefs::CALL_EMPTY_NATIVE;
 
-#ifdef VM_FULL_DEBUG
-    printf("Runtime error: call native with null address\n");
-    vm->dump();
-#endif
+    debuglog(LOG_ERROR, "Empty native address in CALLN");
+    dumpstate(vm);
 
     _THROW(-1)
   }

--- a/source/include/op_move_impl.hpp
+++ b/source/include/op_move_impl.hpp
@@ -13,11 +13,15 @@
 //****************************************************************************//
 
 
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 _DEFINE_OP(MV_8) {
   // move.8 rS,rD
   vm->gpr[_RD(op)].u8() = vm->gpr[_RS(op)].u8();
 }
 _END_OP
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 _DEFINE_OP(MV_16) {
   // move.16 rS,rD
@@ -25,17 +29,23 @@ _DEFINE_OP(MV_16) {
 }
 _END_OP
 
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 _DEFINE_OP(MV_32) {
   // move.32 rS,rD
   vm->gpr[_RD(op)].u32() = vm->gpr[_RS(op)].u32();
 }
 _END_OP
 
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 _DEFINE_OP(MV_64) {
   // move.64 rS,rD
   vm->gpr[_RD(op)].u64() = vm->gpr[_RS(op)].u64();
 }
 _END_OP
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 _DEFINE_OP(BSWP_16) {
   // bswap.16 rS,rD
@@ -44,6 +54,8 @@ _DEFINE_OP(BSWP_16) {
 }
 _END_OP
 
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 _DEFINE_OP(BSWP_32) {
   // bswap.32 rS,rD
   uint32 word32 =  vm->gpr[_RS(op)].u32();
@@ -51,6 +63,8 @@ _DEFINE_OP(BSWP_32) {
   vm->gpr[_RD(op)].u32() = ((word32 & 0x00FF00FF) << 8) | ((word32 & 0xFF00FF00) >> 8);
 }
 _END_OP
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 _DEFINE_OP(BSWP_64) {
   // bswap.64 rS,rD
@@ -63,6 +77,8 @@ _DEFINE_OP(BSWP_64) {
 }
 _END_OP
 
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 _DEFINE_OP(EXG) {
   // exg rS,rD
   uint64 t = vm->gpr[_RD(op)].u64();
@@ -70,6 +86,8 @@ _DEFINE_OP(EXG) {
   vm->gpr[_RS(op)].u64() = t;
 }
 _END_OP
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 _DEFINE_OP(SV) {
   // save r1,r2...
@@ -81,24 +99,26 @@ _DEFINE_OP(SV) {
       *vm->regStack++ = r->u64();
     }
     ++r;
-    mask>>=1;
+    mask >>= 1;
   }
   if (mask) {
     // not all the registers were saved, signifying an overflow
     vm->status = VMDefs::REG_STACK_OVERFLOW;
-    #ifdef VM_FULL_DEBUG
-    printf("Runtime error: register stack overflow\n");
-    vm->dump();
-    #endif
+
+    debuglog(LOG_ERROR, "Register stack overflow");
+    dumpstate(vm);
+
     _THROW(-1)
   }
 }
 _END_OP
 
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 _DEFINE_OP(RS) {
   // restore r1,r2...
   uint16  mask  = _EX_U16;
-  GPR*    r     = vm->gpr + 15;
+  GPR*    r     = vm->gpr + GPR_LAST;
   while (mask && (vm->regStack > vm->regStackBase)) {
     if (mask & 0x8000) {
       r->u64() = *(--vm->regStack);
@@ -109,15 +129,17 @@ _DEFINE_OP(RS) {
   if (mask) {
     // not all the registers were restored, signifying an underflow
     vm->status = VMDefs::REG_STACK_UNDERFLOW;
-    #ifdef VM_FULL_DEBUG
-    printf("Runtime error: register stack underflow\n");
-    vm->dump();
-    #endif
+
+    debuglog(LOG_ERROR, "Register stack underflow");
+    dumpstate(vm);
+
     _THROW(-1)
   }
 
 }
 _END_OP
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 _DEFINE_OP(PUSH_8) {
   uint16 mask =  _EX_U16;
@@ -127,41 +149,45 @@ _DEFINE_OP(PUSH_8) {
       *vm->dataStack.u16++ = r->u8();
     }
     r++;
-    mask>>=1;
+    mask >>= 1;
   }
   if (mask) {
     // not all the data were pushed, signifying an overflow
-    vm->status = VMDefs::REG_STACK_OVERFLOW;
-    #ifdef VM_FULL_DEBUG
-    printf("Runtime error: data stack overflow\n");
-    vm->dump();
-    #endif
+    vm->status = VMDefs::DATA_STACK_OVERFLOW;
+
+    debuglog(LOG_ERROR, "Data stack overflow in PUSH_8");
+    dumpstate(vm);
+
     _THROW(-1)
   }
 }
 _END_OP
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 _DEFINE_OP(PUSH_16) {
   uint16 mask =  _EX_U16;
   GPR*  r = vm->gpr;
   while (mask && (vm->dataStack.u8 < vm->dataStackTop)) {
     if (mask & 1) {
-      *vm->dataStack.u16++ = r->u8();
+      *vm->dataStack.u16++ = r->u16();
     }
     ++r;
-    mask>>=1;
+    mask >>= 1;
   }
   if (mask) {
     // not all the data were pushed, signifying an overflow
-    vm->status = VMDefs::REG_STACK_OVERFLOW;
-    #ifdef VM_FULL_DEBUG
-    printf("Runtime error: data stack overflow\n");
-    vm->dump();
-    #endif
+    vm->status = VMDefs::DATA_STACK_OVERFLOW;
+
+    debuglog(LOG_ERROR, "Data stack overflow in PUSH_16");
+    dumpstate(vm);
+
     _THROW(-1)
   }
 }
 _END_OP
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 _DEFINE_OP(PUSH_32) {
   uint16 mask =  _EX_U16;
@@ -171,19 +197,21 @@ _DEFINE_OP(PUSH_32) {
       *vm->dataStack.u32++ = r->u32();
     }
     ++r;
-    mask>>=1;
+    mask >>= 1;
   }
   if (mask) {
     // not all the data were pushed, signifying an overflow
-    vm->status = VMDefs::REG_STACK_OVERFLOW;
-    #ifdef VM_FULL_DEBUG
-    printf("Runtime error: data stack overflow\n");
-    vm->dump();
-    #endif
+    vm->status = VMDefs::DATA_STACK_OVERFLOW;
+
+    debuglog(LOG_ERROR, "Data stack overflow in PUSH_32");
+    dumpstate(vm);
+
     _THROW(-1)
   }
 }
 _END_OP
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 _DEFINE_OP(PUSH_64) {
   uint16 mask =  _EX_U16;
@@ -193,103 +221,111 @@ _DEFINE_OP(PUSH_64) {
       *vm->dataStack.u64++ = r->u64();
     }
     ++r;
-    mask>>=1;
+    mask >>= 1;
   }
   if (mask) {
     // not all the data were pushed, signifying an overflow
-    vm->status = VMDefs::REG_STACK_OVERFLOW;
-    #ifdef VM_FULL_DEBUG
-    printf("Runtime error: data stack overflow\n");
-    vm->dump();
-    #endif
+    vm->status = VMDefs::DATA_STACK_OVERFLOW;
+
+    debuglog(LOG_ERROR, "Data stack overflow in PUSH_64");
+    dumpstate(vm);
+
     _THROW(-1)
   }
 }
 _END_OP
 
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 _DEFINE_OP(POP_8) {
   uint16 mask =  _EX_U16;
-  GPR*  r = vm->gpr + 15;
+  GPR*  r = vm->gpr + GPR_LAST;
   while (mask && (vm->dataStack.u8 > vm->dataStackBase)) {
     if (mask & 0x8000) {
       r->u8() = *(--vm->dataStack.u16);
     }
     --r;
-    mask<<=1;
+    mask <<= 1;
   }
   if (mask) {
     // not all the data were popped, signifying an underflow
-    vm->status = VMDefs::REG_STACK_UNDERFLOW;
-    #ifdef VM_FULL_DEBUG
-    printf("Runtime error: data stack underflow\n");
-    vm->dump();
-    #endif
+    vm->status = VMDefs::DATA_STACK_UNDERFLOW;
+
+    debuglog(LOG_ERROR, "Data stack underflow in POP_8");
+    dumpstate(vm);
+
     _THROW(-1)
   }
 }
 _END_OP
 
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 _DEFINE_OP(POP_16) {
   uint16 mask =  _EX_U16;
-  GPR*  r = vm->gpr + 15;
+  GPR*  r = vm->gpr + GPR_LAST;
   while (mask && (vm->dataStack.u8 > vm->dataStackBase)) {
     if (mask & 0x8000) {
       r->u16() = *(--vm->dataStack.u16);
     }
     --r;
-    mask<<=1;
+    mask <<= 1;
   }
   if (mask) {
     // not all the data were popped, signifying an underflow
-    vm->status = VMDefs::REG_STACK_UNDERFLOW;
-    #ifdef VM_FULL_DEBUG
-    printf("Runtime error: data stack underflow\n");
-    vm->dump();
-    #endif
+    vm->status = VMDefs::DATA_STACK_UNDERFLOW;
+
+    debuglog(LOG_ERROR, "Data stack underflow in POP_16");
+    dumpstate(vm);
+
     _THROW(-1)
   }
 }
 _END_OP
 
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 _DEFINE_OP(POP_32) {
   uint16 mask =  _EX_U16;
-  GPR*  r = vm->gpr + 15;
+  GPR*  r = vm->gpr + GPR_LAST;
   while (mask && (vm->dataStack.u8 > vm->dataStackBase)) {
     if (mask & 0x8000) {
       r->u32() = *(--vm->dataStack.u32);
     }
     --r;
-    mask<<=1;
+    mask <<= 1;
   }
   if (mask) {
     // not all the data were popped, signifying an underflow
-    vm->status = VMDefs::REG_STACK_UNDERFLOW;
-    #ifdef VM_FULL_DEBUG
-    printf("Runtime error: data stack underflow\n");
-    vm->dump();
-    #endif
+    vm->status = VMDefs::DATA_STACK_UNDERFLOW;
+
+    debuglog(LOG_ERROR, "Data stack underflow in POP_32");
+    dumpstate(vm);
+
     _THROW(-1)
   }
 }
 _END_OP
 
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 _DEFINE_OP(POP_64) {
   uint16 mask =  _EX_U16;
-  GPR*  r = vm->gpr + 15;
+  GPR*  r = vm->gpr + GPR_LAST;
   while (mask && (vm->dataStack.u8 > vm->dataStackBase)) {
     if (mask & 0x8000) {
       r->u64() = *(--vm->dataStack.u64);
     }
     --r;
-    mask<<=1;
+    mask <<= 1;
   }
   if (mask) {
     // not all the data were popped, signifying an underflow
-    vm->status = VMDefs::REG_STACK_UNDERFLOW;
-    #ifdef VM_FULL_DEBUG
-    printf("Runtime error: data stack underflow\n");
-    vm->dump();
-    #endif
+    vm->status = VMDefs::DATA_STACK_UNDERFLOW;
+
+    debuglog(LOG_ERROR, "Data stack underflow in POP_64");
+    dumpstate(vm);
+
     _THROW(-1)
   }
 }

--- a/source/include/vm.hpp
+++ b/source/include/vm.hpp
@@ -17,7 +17,14 @@
 #define _VM_DEFS_HPP_
 #include "machine.hpp"
 
+#define VM_DEBUG
 #define VM_FULL_DEBUG
+#define _VM_LOG_LEVEL 3
+
+#define _VM_LOG_ERROR 0
+#define _VM_LOG_WARN 1
+#define _VM_LOG_INFO 2
+#define _VM_LOG_DEBUG 3
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
@@ -26,6 +33,15 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 namespace ExVM {
+
+  #ifdef VM_DEBUG
+    extern const char* debugLevel(uint32 level);
+    #define debuglog(level, format, args...) if ( _VM_##level <= _VM_LOG_LEVEL) std::printf("[%s] " format "\n", debugLevel((uint32)(_VM_##level)), ## args)
+    #define dumpstate(v) (v)->dump()
+  #else
+    #define debuglog(level, format, args...)
+    #define dumpstate(v)
+  #endif
 
   // Runtime execution engine
   class Interpreter;

--- a/source/include/vm_core.hpp
+++ b/source/include/vm_core.hpp
@@ -32,6 +32,8 @@ namespace ExVM {
     public:
       enum {
         NUM_GPR         = 16,   // Number of general purpose registers
+        GPR_FIRST       = 0,
+        GPR_LAST        = NUM_GPR - 1,
         DEF_REG_STACK   = 1024, // Default register save/restore stack size, in entries
         DEF_DATA_STACK  = 4096, // Default data stack size, in bytes
         DEF_CALL_STACK  = 4096  // Default call stack size, in entries

--- a/source/include/vm_inline.hpp
+++ b/source/include/vm_inline.hpp
@@ -13,7 +13,7 @@
 //****************************************************************************//
 
 #ifndef _VM_INLINE_HPP_
-#define _VM_INLINE_HPP_
+  #define _VM_INLINE_HPP_
 
 namespace ExVM {
 

--- a/source/include/vm_targetmacros.hpp
+++ b/source/include/vm_targetmacros.hpp
@@ -89,20 +89,20 @@
 
   #endif
 
-  #ifdef VM_FULL_DEBUG
+  #ifdef VM_DEBUG
     #define _DECLARE_DATA_SYMBOL(x)             \
     uint16 x = _EX_U16;                         \
     if (x >= vm->dataSymbolCount) {             \
       vm->status = VMDefs::UNKNOWN_DATA_SYMBOL; \
-      printf("Runtime error: Unknown data symbol : %d\n", (int)x); \
-      vm->dump();                               \
+      debuglog(LOG_ERROR, "Runtime error: Unknown data symbol : %d\n", (int)x); \
+      dumpstate(vm);                            \
       _THROW(-1)                                \
     }
   #else
     #define _DECLARE_DATA_SYMBOL(x)             \
     uint16 x = _EX_U16;                         \
     if (x >= vm->dataSymbolCount) {             \
-      vm->status = VMDefs::UNKNOWN_DATA_SYMBOL; \                             \
+      vm->status = VMDefs::UNKNOWN_DATA_SYMBOL; \
       _THROW(-1)                                \
     }
   #endif

--- a/source/vm_core.cpp
+++ b/source/vm_core.cpp
@@ -1,7 +1,7 @@
 //****************************************************************************//
 //**                                                                        **//
 //** File:         vm_core.cpp                                              **//
-//** Description:  Interpreter class definition                                  **//
+//** Description:  Interpreter class definition                             **//
 //** Comment(s):   Internal developer version only                          **//
 //** Library:                                                               **//
 //** Created:      2001-08-29                                               **//
@@ -64,7 +64,7 @@ Interpreter::Interpreter(size_t rStackSize, size_t dStackSize, size_t cStackSize
   callStackTop = callStackBase ? callStackBase + callStackSize : 0;
 
   nativeCodeSymbol = 0;
-  codeSymbol       = 0;  
+  codeSymbol       = 0;
   dataSymbol       = 0;
 
 

--- a/source/vm_debug.cpp
+++ b/source/vm_debug.cpp
@@ -1,0 +1,32 @@
+//****************************************************************************//
+//**                                                                        **//
+//** File:         vm_debug.cpp                                             **//
+//** Description:  Debugging definitions                                    **//
+//** Comment(s):   Internal developer version only                          **//
+//** Library:                                                               **//
+//** Created:      2017-07-18                                               **//
+//** Author(s):    Karl Churchill                                           **//
+//** Note(s):                                                               **//
+//** Copyright:    (C)1996 - , eXtropia Studios                             **//
+//**               All Rights Reserved.                                     **//
+//**                                                                        **//
+//****************************************************************************//
+
+#include "include/vm.hpp"
+
+#ifdef VM_DEBUG
+
+const char* ExVM::debugLevel(uint32 level) {
+  const char* errorLevels[] = {
+    "ERR",
+    "WRN",
+    "INF",
+    "DBG"
+  };
+  if (level < sizeof(errorLevels)/sizeof(const char*)) {
+    return errorLevels[level];
+  }
+  return "---";
+}
+
+#endif

--- a/source/vm_symbol.cpp
+++ b/source/vm_symbol.cpp
@@ -92,9 +92,7 @@ SymbolEnumerator::~SymbolEnumerator() {
     void* ptr = (void*) pBlock;
     pBlock    = pBlock->prevBlock;
 
-#ifdef VM_FULL_DEBUG
-    std::fprintf(stderr, "[INF] Freeing Block at %p\n", ptr);
-#endif
+    debuglog(LOG_DEBUG, "Freeing Block at %p", ptr);
 
     std::free(ptr);
   }
@@ -141,16 +139,12 @@ int SymbolEnumerator::checkBlock() {
     Block* newBlock = (Block*)std::calloc(1, sizeof(Block));
     if (!newBlock) {
 
-#ifdef VM_FULL_DEBUG
-      std::fprintf(stderr, "[ERR] Unable to allocate Block of %u bytes\n", (uint32)sizeof(Block));
-#endif
+      debuglog(LOG_ERROR, "Unable to allocate Block of %u bytes", (uint32)sizeof(Block));
 
       return 0;
     }
 
-#ifdef VM_FULL_DEBUG
-    std::fprintf(stderr, "[INF] Allocate Block of %u bytes at %p\n", (uint32)sizeof(Block), newBlock);
-#endif
+    debuglog(LOG_DEBUG, "Allocated Block of %u bytes at %p", (uint32)sizeof(Block), newBlock);
 
     // Make the newly allocated block the active one
     newBlock->prevBlock    = nodeBlock;
@@ -215,9 +209,7 @@ int SymbolEnumerator::get(const char* symbol) const {
     int code = mapChar(charCode);
     if (code < 0) {
 
-#ifdef VM_FULL_DEBUG
-      std::fprintf(stderr, "[ERR] Illegal Character \'%c\' in symbol\n", charCode);
-#endif
+      debuglog(LOG_ERROR, "Illegal Character \'%c\' in symbol\n", charCode);
 
       return code;
     }
@@ -249,9 +241,7 @@ int SymbolEnumerator::add(const char* symbol) {
   // Check we haven't reached the table size limit
   if (nextSymbolID == maxSymbols) {
 
-#ifdef VM_FULL_DEBUG
-    std::fprintf(stderr, "[ERR] Cannot add symbol %s, table limit of %u entries reached\n", symbol, maxSymbols);
-#endif
+    debuglog(LOG_WARN, "Cannot add symbol %s, table limit of %u entries reached", symbol, maxSymbols);
 
     return Error::TABLE_FULL;
   }
@@ -259,9 +249,7 @@ int SymbolEnumerator::add(const char* symbol) {
   // If we haven't allocated a symbol map yet, we better do it.
   if (!symbolMap && !(symbolMap = (const char**)std::calloc(maxSymbols, sizeof(const char*)))) {
 
-#ifdef VM_FULL_DEBUG
-    std::fprintf(stderr, "[ERR] Could not allocate symbol map\n");
-#endif
+    debuglog(LOG_ERROR, "Could not allocate symbol map");
 
     return Error::OUT_OF_MEMORY;
   }
@@ -269,9 +257,7 @@ int SymbolEnumerator::add(const char* symbol) {
   // If we haven't allocated the root of our trie yet, we better do it.
   if (!rootNode && !(rootNode = allocPNode())) {
 
-#ifdef VM_FULL_DEBUG
-    std::fprintf(stderr, "[ERR] Could not allocate root node\n");
-#endif
+    debuglog(LOG_ERROR, "Could not allocate root node for trie");
 
     return Error::OUT_OF_MEMORY;
   }
@@ -288,9 +274,7 @@ int SymbolEnumerator::add(const char* symbol) {
     int code = mapChar(charCode);
     if (code < 0) {
 
-#ifdef VM_FULL_DEBUG
-      std::fprintf(stderr, "[ERR] Illegal Character \'%c\' in symbol\n", charCode);
-#endif
+      debuglog(LOG_WARN, "Illegal Character \'%c\' in symbol", charCode);
 
       return code;
     }


### PR DESCRIPTION
Changes to basically tidy up debugging so that there are fewer macro interruptions in the source code.

Additionally, loglevel has been introduced for reporting with, in decreasing order of verbosity, LOG_DEBUG > LOG_INFO > LOG_WARN > LOG_ERROR.