### PR TITLE
Milestone/linker #Phase 2

### DIFF
--- a/source/include/vm_linker.hpp
+++ b/source/include/vm_linker.hpp
@@ -21,6 +21,74 @@ namespace ExVM {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
+// RawSegmentData
+//
+// This type represents the expected format of an ExVM object file after loading. An object file will have:
+//
+//   * A code segment containing ExVM opcodes (may be zero length)
+//   * A data segment containing global data entries (may be zero length)
+//   * A name heap - a set of strings for all the symbol names that are imported and exported. This is shared so that
+//     a string need only be declared once if it is both exported and imported by the same code.
+//   * A table of Symbols Exported - contains the type and offset of the Symbol within the appropriate Segment and
+//     the offset of the symbol name in the name heap.
+//   * A table of Symbols Imported - Same structure as the Exported set, with the distinction that the offset indicates
+//     the offset into the code Segment where the resolved Symbol ID should be injected at runtime.
+//
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+
+  struct RawSegmentData {
+    enum {
+      // Valid for exported and imported symbols
+      TYPE_CODE   = 0x00000000,
+
+      // Valid for exported and imported symbols
+      TYPE_DATA   = 0x40000000,
+
+      // Valid for imported symbols only
+      TYPE_NATIVE = 0x80000000,
+
+      // Masks used in entries table
+      TYPE_MASK   = 0xC0000000,
+      OFFSET_MASK = ~TYPE_MASK
+    };
+
+    struct SymbolRef {
+      uint32 symbolData;
+
+      // For exports, defines the offset in either the data or code Segment of the named entitiy.
+      // For imports, defines the offset in the codeSegment where the resolved Symbol ID should be injected.
+      uint32 offset;
+
+      // Extract the expected name of the synbolData reference from the symbolNames heap
+      const char* getSymbolName(const char* base) {
+        return &base[(symbolData & OFFSET_MASK)];
+      }
+
+      // Extract the SymbolType from the symbolData reference.
+      uint32 getSymbolType() {
+        return symbolData & TYPE_MASK;
+      }
+    };
+
+    // Location of the Code Segment, an array of 16-bit ExVM instruction words
+    uint16*      codeSegment;
+
+    // Location of the Data Segment
+    void*        dataSegment;
+
+    // Location of the symbol name heap
+    const char*  symbolNames;
+
+    // Symbols that are exported
+    SymbolRef *exports;
+
+    // Symbols that are imported
+    SymbolRef *imports;
+  };
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//
 // Linker
 //
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/source/include/vm_linker.hpp
+++ b/source/include/vm_linker.hpp
@@ -127,17 +127,34 @@ namespace ExVM {
       SymbolMap* nativeCodeSymbols;
       SymbolMap* dataSymbols;
 
-      RawSegmentData* rawSegments;
-      uint32          numRawSegments;
+      // RawSegmentData pointer table, kkeeps track of all the RawSegmentData entries that have been added.
+      RawSegmentData** rawSegments;
+      uint32           numRawSegments;
+
+      // Current allocation size for RawSegmentData array
+      uint32 currSize;
+
+      // Increment size for RawSegmentData array
+      uint32 delta;
 
       int defineSymbol(SymbolMap*& map, const char* name, const void* address);
 
     public:
+
       class Error : public ExVM::Error {
         enum {
           INVALID_SEGMENT = -200
         };
       };
+
+      enum {
+        DEF_INI_TABLE_SIZE     = 128,
+        DEF_INC_TABLE_DELTA    = 128
+      };
+
+      uint32 getNumSegments() const {
+        return numRawSegments;
+      }
 
       int defineNativeCode(const char* name, NativeCall native) {
         return defineSymbol(nativeCodeSymbols, name, (const void*)native);
@@ -151,12 +168,13 @@ namespace ExVM {
         return defineSymbol(dataSymbols, name, data);
       }
 
+      // Add a RawSegmentData for linking
       int addRawSegment(RawSegmentData* rawSegment);
 
       // Run the linking Process
       int link();
 
-      Linker();
+      Linker(uint32 defSegmentCount = DEF_INI_TABLE_SIZE, uint32 defSegmentDelta = DEF_INC_TABLE_DELTA);
       ~Linker();
 
     private:

--- a/source/include/vm_linker.hpp
+++ b/source/include/vm_linker.hpp
@@ -39,14 +39,17 @@ namespace ExVM {
 
   struct RawSegmentData {
     enum {
-      // Valid for exported and imported symbols
-      TYPE_CODE   = 0x00000000,
+      MAGIC       = 0x4578564D, // E x V M
+      TYPE_UNDEF  = 0x00000000,
 
       // Valid for exported and imported symbols
-      TYPE_DATA   = 0x40000000,
+      TYPE_CODE   = 0x40000000,
+
+      // Valid for exported and imported symbols
+      TYPE_DATA   = 0x80000000,
 
       // Valid for imported symbols only
-      TYPE_NATIVE = 0x80000000,
+      TYPE_NATIVE = 0xC0000000,
 
       // Masks used in entries table
       TYPE_MASK   = 0xC0000000,
@@ -81,10 +84,10 @@ namespace ExVM {
     const char*  nameSegment;
 
     // Symbols that are exported
-    SymbolRef*   exports;
+    SymbolRef*   exportTable;
 
     // Symbols that are imported
-    SymbolRef*   imports;
+    SymbolRef*   importTable;
 
     // This section represents the beginning of the data that is actually loaded.
 
@@ -92,10 +95,10 @@ namespace ExVM {
     uint32 magic;
 
     // The number of exported symbols
-    uint32 exportsLength;
+    uint32 exportTableLength;
 
     // The number of imported synbo;s
-    uint32 importsLength;
+    uint32 importTableLength;
 
     // The number of ExVM instruction words (16-bit) in the full codeSegment
     uint32 codeSegmentLength;
@@ -142,8 +145,10 @@ namespace ExVM {
     public:
 
       class Error : public ExVM::Error {
+        public:
         enum {
-          INVALID_SEGMENT = -200
+          INVALID_SEGMENT     = -200,
+          ILLEGAL_EXPORT_TYPE = -201
         };
       };
 

--- a/source/include/vm_symbol.hpp
+++ b/source/include/vm_symbol.hpp
@@ -203,6 +203,10 @@ namespace ExVM {
       // Define a new Symbol
       int define(const char* name, const void* address);
 
+      int getID(const char* name) const {
+        return SymbolNameEnumerator::getID(name);
+      }
+
       // obtain a symbol by a previous ID
       const Symbol* get(uint32 symbolID) const {
         if (!symbols || symbolID >= size()) {

--- a/source/include/vm_symbol.hpp
+++ b/source/include/vm_symbol.hpp
@@ -191,7 +191,6 @@ namespace ExVM {
         return SymbolNameEnumerator::getNextID();
       }
 
-
       // Lookup a defined symbol by name
       const Symbol* find(const char* name) const {
         int i = SymbolNameEnumerator::getID(name);

--- a/source/test_linker.cpp
+++ b/source/test_linker.cpp
@@ -86,7 +86,7 @@ int main() {
     std::puts("\tFAILED");
   }
 
-
+  std::printf("Sizeof RawSegmentData: %u\n", sizeof(RawSegmentData));
 
   return 0;
 }

--- a/source/test_linker.cpp
+++ b/source/test_linker.cpp
@@ -20,73 +20,141 @@
 
 using namespace ExVM;
 
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 void nativePrint(Interpreter* vm) {
   std::puts(vm->getReg(_r0).pCh());
 }
 
-
-uint16 dummy[] = {
-  _ret
+// Mock code segment defining a single do nothing function
+uint16 mockCodeSegment[] = {
+  _ret,
+  0xFFFF, // DUMMY - we want to inject a resolved symbol ID here
+  0xFFFF,
+  0xFFFF,
+  0xFFFF,
+  0xFFFF,
 };
 
-const char* greeting = "Hello World!!!\n";
-const char* leaving  = "Bye World!!!\n";
+// Mock data segment defining four 32 bit words
+uint32 mockDataSegment[] = {
+  0xABADCAFE,
+  0xDEADBEEF,
+  0x01234567,
+  0x89ABCDEF
+};
+
+// Mock name segment
+char mockNameSegment[] =
+  // Name               Offset
+  "main\0"           // 0
+  "nativePrint\0"    // 5
+  "zero\0"           // 17
+  "one\0"            // 22
+  "two\0"            // 26
+  "three\0";         // 30
+
+// Mock export symbol table
+RawSegmentData::SymbolRef mockExports[] = {
+  {
+    0 | RawSegmentData::TYPE_CODE,  // Offset of the symbol name "main" in the name segment OR'd with CODE
+    0                               // Offset into the code segment (in words)
+  }, {
+    17 | RawSegmentData::TYPE_DATA, // Offset of the symbol name "zero" in the name segment OR'd with DATA
+    0                               // Offset into the data segment (in bytes)
+  }, {
+    22 | RawSegmentData::TYPE_DATA,
+    4,
+  }, {
+    26 | RawSegmentData::TYPE_DATA,
+    8,
+  }, {
+    30 | RawSegmentData::TYPE_DATA,
+    12,
+  },
+
+};
+
+// Mock import symbol table
+RawSegmentData::SymbolRef mockImports[] = {
+  {
+    5 | RawSegmentData::TYPE_NATIVE, // Offset of the symbol name "nativePrint" in the name segment OR'd with DATA
+    1                                // Offset into the code segment where the symbol ID will be injected
+  }, {
+    30 | RawSegmentData::TYPE_DATA, // Offset of the symbol name "three" in the name segment OR'd with DATA
+    2                               // Offset into the code segment where the symbol ID will be injected
+  }, {
+    26 | RawSegmentData::TYPE_DATA, // Offset of the symbol name "two" in the name segment OR'd with DATA
+    3                               // Offset into the code segment where the symbol ID will be injected
+  }, {
+    22 | RawSegmentData::TYPE_DATA, // Offset of the symbol name "one" in the name segment OR'd with DATA
+    4                               // Offset into the code segment where the symbol ID will be injected
+  }, {
+    17 | RawSegmentData::TYPE_DATA, // Offset of the symbol name "zero" in the name segment OR'd with DATA
+    5                               // Offset into the code segment where the symbol ID will be injected
+  }
+
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 int main() {
 
+  RawSegmentData mockLoadSegment = {
+    mockCodeSegment,                                         // .codeSegment
+    mockDataSegment,                                         // .dataSegment
+    mockNameSegment,                                         // .nameSegment
+    mockExports,                                             // .exportTable
+    mockImports,                                             // .importTable
+    RawSegmentData::MAGIC,                                   // .magic
+    sizeof(mockExports) / sizeof(RawSegmentData::SymbolRef), // .exportTableLength
+    sizeof(mockImports) / sizeof(RawSegmentData::SymbolRef), // .importTableLength
+    sizeof(mockCodeSegment) / sizeof(uint16),                // .codeSegmentLength
+    sizeof(mockDataSegment),                                 // .dataSegmentLength
+    sizeof(mockNameSegment)                                  // .nameSegmentLength
+  };
+
+  std::printf(
+    "RawSegmentData {\n"
+    "\tcodeSegment       : %p\n"
+    "\tdataSegment       : %p\n"
+    "\tnameSegment       : %p\n"
+    "\texportTable       : %p\n"
+    "\timportTable       : %p\n"
+    "\tmagic             : 0x%08X\n"
+    "\texportTableLength : %u\n"
+    "\timportTableLength : %u\n"
+    "\tcodeSegmentLength : %u\n"
+    "\tdataSegmentLength : %u\n"
+    "\tnameSegmentLength : %u\n"
+    "}\n",
+    mockLoadSegment.codeSegment,
+    mockLoadSegment.dataSegment,
+    mockLoadSegment.nameSegment,
+    mockLoadSegment.exportTable,
+    mockLoadSegment.importTable,
+    mockLoadSegment.magic,
+    mockLoadSegment.exportTableLength,
+    mockLoadSegment.importTableLength,
+    mockLoadSegment.codeSegmentLength,
+    mockLoadSegment.dataSegmentLength,
+    mockLoadSegment.nameSegmentLength
+  );
+
+  std::puts("Code Segment before linking...");
+  for (uint32 i=0; i<mockLoadSegment.codeSegmentLength; i++) {
+    std::printf("%u : 0x%04X\n", i, mockLoadSegment.codeSegment[i]);
+  }
+
   Linker testLinker;
-  int result;
+  testLinker.defineNativeCode("nativePrint", nativePrint);
+  testLinker.addRawSegment(&mockLoadSegment);
+  testLinker.link();
 
-  std::puts("Testing testLinker.defineData(\"greeting\"), expect ID 0");
-
-  result = testLinker.defineData("greeting", greeting);
-  if (result == 0) {
-    std::puts("\tSUCCESS");
-  } else {
-    std::puts("\tFAILED");
+  std::puts("Code Segment after linking...");
+  for (uint32 i=0; i<mockLoadSegment.codeSegmentLength; i++) {
+    std::printf("%u : 0x%04X\n", i, mockLoadSegment.codeSegment[i]);
   }
-
-  std::puts("Testing testLinker.defineData(\"leaving\"), expect ID 1");
-  result = testLinker.defineData("leaving", leaving);
-  if (result == 1) {
-    std::puts("\tSUCCESS");
-  } else {
-    std::puts("\tFAILED");
-  }
-
-  std::puts("Testing testLinker.defineData(\"greeting\"), expect SymbolEnumerator::Error::DUPLICATE_SYMBOL");
-  result = testLinker.defineData("greeting", greeting);
-  if (result == SymbolNameEnumerator::Error::DUPLICATE_SYMBOL) {
-    std::puts("\tSUCCESS");
-  } else {
-    std::puts("\tFAILED");
-  }
-
-  std::puts("Testing testLinker.defineData(\"leaving\"), expect SymbolEnumerator::Error::DUPLICATE_SYMBOL");
-  result = testLinker.defineData("leaving", leaving);
-  if (result == SymbolNameEnumerator::Error::DUPLICATE_SYMBOL) {
-    std::puts("\tSUCCESS");
-  } else {
-    std::puts("\tFAILED");
-  }
-
-  std::puts("Testing testLinker.defineNativeCode(\"greeting\"), expect ID 0");
-  result = testLinker.defineNativeCode("print", nativePrint);
-  if (result == 0) {
-    std::puts("\tSUCCESS");
-  } else {
-    std::puts("\tFAILED");
-  }
-
-  std::puts("Testing testLinker.defineCode(\"main\"), expect ID 0");
-  result = testLinker.defineCode("main", dummy);
-  if (result == 0) {
-    std::puts("\tSUCCESS");
-  } else {
-    std::puts("\tFAILED");
-  }
-
-  std::printf("Sizeof RawSegmentData: %u\n", sizeof(RawSegmentData));
 
   return 0;
 }

--- a/source/vm_symbol.cpp
+++ b/source/vm_symbol.cpp
@@ -136,12 +136,9 @@ int SymbolNameEnumerator::checkBlock() {
   if (!nodeBlock || nodeBlock->nextFree == NODE_BLOCKSIZE) {
     Block* newBlock = (Block*)std::calloc(1, sizeof(Block));
     if (!newBlock) {
-
       debuglog(LOG_ERROR, "Unable to allocate Block of %u bytes", (uint32)sizeof(Block));
-
       return 0;
     }
-
     debuglog(LOG_DEBUG, "Allocated Block of %u bytes at %p", (uint32)sizeof(Block), newBlock);
 
     // Make the newly allocated block the active one
@@ -211,9 +208,7 @@ int SymbolNameEnumerator::getID(const char* name) const {
   while ( (charCode = *name++) ) {
     int code = mapChar(charCode);
     if (code < 0) {
-
       debuglog(LOG_ERROR, "Illegal Character \'%c\' in symbol\n", charCode);
-
       return code;
     }
 
@@ -248,17 +243,13 @@ int SymbolNameEnumerator::enumerate(const char* name) {
 
   // Check we haven't reached the table size limit
   if (isFull()) {
-
     debuglog(LOG_WARN, "Cannot add symbol %s, table limit of %u entries reached", name, maxSymbolID);
-
     return Error::TABLE_FULL;
   }
 
   // If we haven't allocated the root of our trie yet, we better do it.
   if (!rootNode && !(rootNode = allocPNode())) {
-
     debuglog(LOG_ERROR, "Could not allocate root node for trie");
-
     return Error::OUT_OF_MEMORY;
   }
 
@@ -273,9 +264,7 @@ int SymbolNameEnumerator::enumerate(const char* name) {
 
     int code = mapChar(charCode);
     if (code < 0) {
-
       debuglog(LOG_WARN, "Illegal Character \'%c\' in symbol", charCode);
-
       return code;
     }
 
@@ -335,11 +324,8 @@ SymbolMap::SymbolMap(uint32 maxSize, uint32 iniSize, uint32 delta) :
 SymbolMap::~SymbolMap() {
   if (symbols) {
     std::free(symbols);
-
     debuglog(LOG_DEBUG, "Freed SymbolMap::symbolList");
-
   }
-
   debuglog(LOG_DEBUG, "Destroyed SymbolMap");
 }
 
@@ -349,9 +335,7 @@ int SymbolMap::define(const char* name, const void* address) {
 
   // Protect against null
   if (!address) {
-
     debuglog(LOG_ERROR, "Unable to define Symbol %s at null address", name);
-
     return Error::ILLEGAL_ARGUMENT;
   }
 
@@ -365,20 +349,16 @@ int SymbolMap::define(const char* name, const void* address) {
       !symbols &&
       !(symbols = (Symbol*)std::calloc(currSize, sizeof(Symbol)))
     ) {
-
       debuglog(LOG_ERROR, "Unable to allocate initial Symbol table for %u entries", currSize);
-
       return Error::OUT_OF_MEMORY;
     }
 
     // Time to expand symbol table?
     if ((uint32) result >= currSize) {
-      uint32 newSize = currSize + delta;
+      uint32  newSize     = currSize + delta;
       Symbol* growSymbols = (Symbol*)std::realloc(symbols, newSize * sizeof(Symbol));
       if (!growSymbols) {
-
         debuglog(LOG_ERROR, "Unable to grow Symbol table to %u entries", newSize);
-
         return Error::OUT_OF_MEMORY;
       }
 
@@ -391,17 +371,13 @@ int SymbolMap::define(const char* name, const void* address) {
     symbols[result].address.raw = address;
 
     debuglog(LOG_INFO, "Added symbol #%d \'%s\' @ %p", result, name, address);
-
   } else {
-
-      debuglog(LOG_WARN, "Failed to add \'%s\', result %d", name, result);
-
+    debuglog(LOG_WARN, "Failed to add \'%s\', result %d", name, result);
   }
 
   return result;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
 
 


### PR DESCRIPTION
Implemented a minimally functional linker that:

- Operates on a simplified structure (RawSegmentData) that aims to model what the ExVM code will look like once loaded from disk
- Performs two passes over a set of RawSegmentData representing the code to be linked
- First pass collects all of the exported code and data symbols from each RawSegmentData and enumerates them
- Second pass processes all of the imported code, data and native symbols, reconciling them with the enumerated ones and injects the appropriate symbol ID for each into the correct offset within code section of the RawSegmentData being processed

Example output from test:

RawSegmentData {
        codeSegment       : 0x604140
        dataSegment       : 0x604130
        nameSegment       : 0x604100
        exportTable       : 0x6040c0
        importTable       : 0x604080
        magic             : 0x4578564D
        exportTableLength : 5
        importTableLength : 5
        codeSegmentLength : 6
        dataSegmentLength : 16
        nameSegmentLength : 37
}
Code Segment before linking...
0 : 0x5100
1 : 0xFFFF
2 : 0xFFFF
3 : 0xFFFF
4 : 0xFFFF
5 : 0xFFFF
[DBG] Linker Created Linker
[DBG] SymbolNameEnumerator Created SymbolNameEnumerator with maxSize 65536
[DBG] SymbolMap Created SymbolMap, initial size 128, max size 65536, grow size 128
[DBG] checkBlock Allocated Block of 18448 bytes at 0x166b060
[INF] define Added symbol #0 'nativePrint' @ 0x4020c0
[INF] addRawSegment Added RawSegmentData instance at 0x7ffd6d9ce010 as entry 0
[INF] link Beginning link process
[INF] enumerateAllSymbols Processing RawSegmentData[0] 0x7ffd6d9ce010 Export Symbols
[INF] enumerateAllSymbols Processing exported TYPE_CODE symbol 'main' at 0x604140
[DBG] SymbolNameEnumerator Created SymbolNameEnumerator with maxSize 65536
[DBG] SymbolMap Created SymbolMap, initial size 128, max size 65536, grow size 128
[DBG] checkBlock Allocated Block of 18448 bytes at 0x16704d0
[INF] define Added symbol #0 'main' @ 0x604140
[INF] enumerateAllSymbols Processing exported TYPE_DATA symbol 'zero' at 0x604130
[DBG] SymbolNameEnumerator Created SymbolNameEnumerator with maxSize 65536
[DBG] SymbolMap Created SymbolMap, initial size 128, max size 65536, grow size 128
[DBG] checkBlock Allocated Block of 18448 bytes at 0x1675530
[INF] define Added symbol #0 'zero' @ 0x604130
[INF] enumerateAllSymbols Processing exported TYPE_DATA symbol 'one' at 0x604134
[INF] define Added symbol #1 'one' @ 0x604134
[INF] enumerateAllSymbols Processing exported TYPE_DATA symbol 'two' at 0x604138
[INF] define Added symbol #2 'two' @ 0x604138
[INF] enumerateAllSymbols Processing exported TYPE_DATA symbol 'three' at 0x60413c
[INF] define Added symbol #3 'three' @ 0x60413c
[INF] resolveToEnumerated Processing RawSegmentData[0] 0x7ffd6d9ce010 Import Symbols
[INF] resolveToEnumerated Processing imported TYPE_NATIVE symbol 'nativePrint'
[INF] resolveToEnumerated       Resolved symbol 'nativePrint' to ID 0 at 0x604130
[INF] resolveToEnumerated Injecting symbol 'nativePrint' ID 0 into code segment at offset 1 [0x604142]
[INF] resolveToEnumerated Processing imported TYPE_DATA symbol 'three'
[INF] resolveToEnumerated       Resolved symbol 'three' to ID 3 at 0x60413c
[INF] resolveToEnumerated Injecting symbol 'three' ID 3 into code segment at offset 2 [0x604144]
[INF] resolveToEnumerated Processing imported TYPE_DATA symbol 'two'
[INF] resolveToEnumerated       Resolved symbol 'two' to ID 2 at 0x604138
[INF] resolveToEnumerated Injecting symbol 'two' ID 2 into code segment at offset 3 [0x604146]
[INF] resolveToEnumerated Processing imported TYPE_DATA symbol 'one'
[INF] resolveToEnumerated       Resolved symbol 'one' to ID 1 at 0x604134
[INF] resolveToEnumerated Injecting symbol 'one' ID 1 into code segment at offset 4 [0x604148]
[INF] resolveToEnumerated Processing imported TYPE_DATA symbol 'zero'
[INF] resolveToEnumerated       Resolved symbol 'zero' to ID 0 at 0x604130
[INF] resolveToEnumerated Injecting symbol 'zero' ID 0 into code segment at offset 5 [0x60414a]
Code Segment after linking...
0 : 0x5100
1 : 0x0000
2 : 0x0003
3 : 0x0002
4 : 0x0001
5 : 0x0000
[DBG] ~SymbolMap Freed SymbolMap::symbolList
[DBG] ~SymbolMap Destroyed SymbolMap
[DBG] ~SymbolNameEnumerator Freeing Block at 0x16704d0
[DBG] ~SymbolNameEnumerator Destroyed SymbolNameEnumerator
[DBG] ~SymbolMap Freed SymbolMap::symbolList
[DBG] ~SymbolMap Destroyed SymbolMap
[DBG] ~SymbolNameEnumerator Freeing Block at 0x166b060
[DBG] ~SymbolNameEnumerator Destroyed SymbolNameEnumerator
[DBG] ~SymbolMap Freed SymbolMap::symbolList
[DBG] ~SymbolMap Destroyed SymbolMap
[DBG] ~SymbolNameEnumerator Freeing Block at 0x1675530
[DBG] ~SymbolNameEnumerator Destroyed SymbolNameEnumerator
[DBG] ~Linker Destroyed Linker

