### PR TITLE
Milestone/linker - Symbol ID Range Expansion

### DIFF
--- a/source/include/vm.hpp
+++ b/source/include/vm.hpp
@@ -108,7 +108,10 @@ namespace ExVM {
       } VMStatus;
 
       enum {
-        SYMBOL_ID_SIZE = 2,
+        // Symbol sizes in bits
+        DATA_SYMBOL_ID_SIZE   = 20,
+        CODE_SYMBOL_ID_SIZE   = 20,
+        NATIVE_SYMBOL_ID_SIZE = 20
       };
   };
 

--- a/source/include/vm_codemacros.hpp
+++ b/source/include/vm_codemacros.hpp
@@ -40,19 +40,19 @@ inline uint16 _float32LSW(float32 f) {
 }
 
 // covnert a 32-bit integer immediate into 16-bit words
-#define _INLINE32(x) (uint16)(( (uint32)(x) )>>16), \
-                     (uint16)(( (uint32)(x) )&0xFFFF)
+#define _INLINE32(x) (uint16)(( (uint32)(x) ) >> 16), \
+                     (uint16)(( (uint32)(x) ) & 0xFFFF)
 
 #if X_PTRSIZE == XA_PTRSIZE64
-#define _INLINEPTR(x) (uint16)(( (uint64)(x) )>>48), \
-                      (uint16)((( (uint64)(x) )>>32)&0xFFFF), \
-                      (uint16)((( (uint64)(x) )>>16)&0xFFFF), \
-                      (uint16)(( (uint64)(x) )&0xFFFF)
+#define _INLINEPTR(x) (uint16)(( (uint64)(x) ) >> 48), \
+                      (uint16)((( (uint64)(x) ) >> 32) & 0xFFFF), \
+                      (uint16)((( (uint64)(x) ) >> 16) & 0xFFFF), \
+                      (uint16)(( (uint64)(x) ) & 0xFFFF)
 #else
 #define _INLINEPTR(x) (uint16)0, \
                       (uint16)0, \
-                      (uint16)((( (uint32)(x) )>>16)&0xFFFF), \
-                      (uint16)(((uint32)(x))&0xFFFF)
+                      (uint16)((( (uint32)(x) ) >> 16) & 0xFFFF), \
+                      (uint16)(((uint32)(x)) & 0xFFFF)
 #endif
 
 // convert a 32-bit float immediate into 16-bit words
@@ -76,17 +76,17 @@ inline uint16 _float32LSW(float32 f) {
 }
 
 // covnert a 32-bit integer immediate into 16-bit words
-#define _INLINE32(x) (( (uint32)(x) )&0xFFFF), \
-                     (( (uint32)(x) )>>16)
+#define _INLINE32(x) (( (uint32)(x) ) & 0xFFFF), \
+                     (( (uint32)(x) ) >> 16)
 
 #if X_PTRSIZE == XA_PTRSIZE64
-  #define _INLINEPTR(x) (uint16)(( (uint64)(x) )&0xFFFF), \
-                        (uint16)((( (uint64)(x) )>>16)&0xFFFF), \
-                        (uint16)((( (uint64)(x) )>>32)&0xFFFF), \
-                        (uint16)(( (uint64)(x) )>>48)
+  #define _INLINEPTR(x) (uint16)(( (uint64)(x) ) & 0xFFFF), \
+                        (uint16)((( (uint64)(x) ) >> 16) & 0xFFFF), \
+                        (uint16)((( (uint64)(x) ) >> 32) & 0xFFFF), \
+                        (uint16)(( (uint64)(x) ) >> 48)
 #else
-  #define _INLINEPTR(x) (uint16)(( (uint32)(x) )&0xFFFF), \
-                        (uint16)(( (uint32)(x) )>>16), \
+  #define _INLINEPTR(x) (uint16)(( (uint32)(x) ) & 0xFFFF), \
+                        (uint16)(( (uint32)(x) ) >> 16), \
                         (uint16)0, \
                         (uint16)0
 #endif
@@ -98,7 +98,8 @@ inline uint16 _float32LSW(float32 f) {
 #endif
 
 
-////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 // register names
 #define _r0 0
 #define _r1 1
@@ -137,9 +138,11 @@ inline uint16 _float32LSW(float32 f) {
 
 #define _SYM_NATIVE(x) sym_native_##x
 #define _SYM_CODE(x) sym_code_##x
-#define _SYM_DATA(x) sym_data_##x
+#define _SYM_DATA_LOWER(x) (uint16)(sym_data_##x & 0xFFFF)
+#define _SYM_DATA_UPPER(x) (uint16)((sym_data_##x & 0xF0000) >> 12)
 
-////////////////////////////////////////////////////////////////////////////////
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 //  begin a named array of 16 bit words representing a code block:
 //
@@ -148,56 +151,57 @@ inline uint16 _float32LSW(float32 f) {
 //
 //  }; <- don't forget the trailing semicolon!
 //
-////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 
 #define _VM_CODE(x) uint16 _vmCode##x[] =
 
 
-////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 //  refer to a named code block:
 //
 //  uint16* code = _VM_ENTRY(myFunction);
 //
-////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 #define _VM_ENTRY(x) (_vmCode##x)
 
 #define _VM_EXTERN(x) extern uint16 _vmCode##x[]
 
-////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 //  obtain the size (in words) of a named code block:
 //
 //  size_t size = _VM_CODE_SIZE(myFunction);
 //
-////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-#define _VM_CODE_SIZE(x) (sizeof(_vmCode##x)/sizeof(uint16))
+#define _VM_CODE_SIZE(x) (sizeof(_vmCode##x) / sizeof(uint16))
 
-////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 //  create an opcode word:
 //
 //  _MKOP(<name>)
 //
-//  generates the 16-bit word for the named opcode, ie (VMDefs::_<name>)<<8
+//  generates the 16-bit word for the named opcode, ie (VMDefs::_<name>) << 8
 //
-////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-#define _MKOP(x) ((VMDefs::_##x)<<8)
+#define _MKOP(x) ((VMDefs::_##x) << 8)
 
 
-////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 //  control group
 //
-////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 #define _nop                  _MKOP(NOP),
 #define _brk                  _MKOP(BRK),
 
-////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 //  load group
 //
@@ -206,52 +210,52 @@ inline uint16 _float32LSW(float32 f) {
 //  _operation(_rS, offset, _rD)     - indirect with displacement
 //  _operation(_rS, _rI, scale, _rD) - inirect scaled indexed
 //
-////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-#define _ldq(n,r)             _MKOP(LDQ)|(n)<<4|(r),
-#define _ld_16_i8(n,r)        _MKOP(LD_I16_8)|(r), (n),
-#define _ld_16_i16(n,r)       _MKOP(LD_I16_16)|(r), (n),
-#define _ld_16_i32(n,r)       _MKOP(LD_I16_32)|(r), (n),
-#define _ld_16_i64(n,r)       _MKOP(LD_I16_64)|(r), (n),
-#define _ld_32_i32(n,r)       _MKOP(LD_I32_32)|(r), _INLINE32(n),
-#define _ld_32_i64(n,r)       _MKOP(LD_I32_64)|(r), _INLINE32(n),
-#define _ld_32_f32(n,r)       _MKOP(LD_F32)|(r), _INLINEF32(n),
-#define _ld_ri_8(s,d)         _MKOP(LD_RI_8)|(s)<<4|(d),
-#define _ld_ri_16(s,d)        _MKOP(LD_RI_16)|(s)<<4|(d),
-#define _ld_ri_32(s,d)        _MKOP(LD_RI_32)|(s)<<4|(d),
-#define _ld_ri_64(s,d)        _MKOP(LD_RI_64)|(s)<<4|(d),
-#define _ld_ripi_8(s,d)       _MKOP(LD_RIPI_8)|(s)<<4|(d),
-#define _ld_ripi_16(s,d)      _MKOP(LD_RIPI_16)|(s)<<4|(d),
-#define _ld_ripi_32(s,d)      _MKOP(LD_RIPI_32)|(s)<<4|(d),
-#define _ld_ripi_64(s,d)      _MKOP(LD_RIPI_64)|(s)<<4|(d),
-#define _ld_ripd_8(s,d)       _MKOP(LD_RIPD_8)|(s)<<4|(d),
-#define _ld_ripd_16(s,d)      _MKOP(LD_RIPD_16)|(s)<<4|(d),
-#define _ld_ripd_32(s,d)      _MKOP(LD_RIPD_32)|(s)<<4|(d),
-#define _ld_ripd_64(s,d)      _MKOP(LD_RIPD_64)|(s)<<4|(d),
-#define _ld_rid_8(s,o,d)      _MKOP(LD_RID_8)|(s)<<4|(d),
-#define _ld_rid_16(s,o,d)     _MKOP(LD_RID_16)|(s)<<4|(d), (uint16)(o),
-#define _ld_rid_32(s,o,d)     _MKOP(LD_RID_32)|(s)<<4|(d), (uint16)(o),
-#define _ld_rid_64(s,o,d)     _MKOP(LD_RID_64)|(s)<<4|(d), (uint16)(o),
-#define _ld_rii_8(s,i,f,d)    _MKOP(LD_RII_8)|(s)<<4|(d), ((f)<<8)|((i)&0xF),
-#define _ld_rii_16(s,i,f,d)   _MKOP(LD_RII_16)|(s)<<4|(d), ((f)<<8)|((i)&0xF),
-#define _ld_rii_32(s,i,f,d)   _MKOP(LD_RII_32)|(s)<<4|(d), ((f)<<8)|((i)&0xF),
-#define _ld_rii_64(s,i,f,d)   _MKOP(LD_RII_64)|(s)<<4|(d), ((f)<<8)|((i)&0xF),
+#define _ldq(n,r)             _MKOP(LDQ)        | (n) << 4 | (r),
+#define _ld_16_i8(n,r)        _MKOP(LD_I16_8)   | (r), (n),
+#define _ld_16_i16(n,r)       _MKOP(LD_I16_16)  | (r), (n),
+#define _ld_16_i32(n,r)       _MKOP(LD_I16_32)  | (r), (n),
+#define _ld_16_i64(n,r)       _MKOP(LD_I16_64)  | (r), (n),
+#define _ld_32_i32(n,r)       _MKOP(LD_I32_32)  | (r), _INLINE32(n),
+#define _ld_32_i64(n,r)       _MKOP(LD_I32_64)  | (r), _INLINE32(n),
+#define _ld_32_f32(n,r)       _MKOP(LD_F32)     | (r), _INLINEF32(n),
+#define _ld_ri_8(s,d)         _MKOP(LD_RI_8)    | (s) << 4 | (d),
+#define _ld_ri_16(s,d)        _MKOP(LD_RI_16)   | (s) << 4 | (d),
+#define _ld_ri_32(s,d)        _MKOP(LD_RI_32)   | (s) << 4 | (d),
+#define _ld_ri_64(s,d)        _MKOP(LD_RI_64)   | (s) << 4 | (d),
+#define _ld_ripi_8(s,d)       _MKOP(LD_RIPI_8)  | (s) << 4 | (d),
+#define _ld_ripi_16(s,d)      _MKOP(LD_RIPI_16) | (s) << 4 | (d),
+#define _ld_ripi_32(s,d)      _MKOP(LD_RIPI_32) | (s) << 4 | (d),
+#define _ld_ripi_64(s,d)      _MKOP(LD_RIPI_64) | (s) << 4 | (d),
+#define _ld_ripd_8(s,d)       _MKOP(LD_RIPD_8)  | (s) << 4 | (d),
+#define _ld_ripd_16(s,d)      _MKOP(LD_RIPD_16) | (s) << 4 | (d),
+#define _ld_ripd_32(s,d)      _MKOP(LD_RIPD_32) | (s) << 4 | (d),
+#define _ld_ripd_64(s,d)      _MKOP(LD_RIPD_64) | (s) << 4 | (d),
+#define _ld_rid_8(s,o,d)      _MKOP(LD_RID_8)   | (s) << 4 | (d),
+#define _ld_rid_16(s,o,d)     _MKOP(LD_RID_16)  | (s) << 4 | (d), (uint16)(o),
+#define _ld_rid_32(s,o,d)     _MKOP(LD_RID_32)  | (s) << 4 | (d), (uint16)(o),
+#define _ld_rid_64(s,o,d)     _MKOP(LD_RID_64)  | (s) << 4 | (d), (uint16)(o),
+#define _ld_rii_8(s,i,f,d)    _MKOP(LD_RII_8)   | (s) << 4 | (d), ((f) << 8) | ((i)&0xF),
+#define _ld_rii_16(s,i,f,d)   _MKOP(LD_RII_16)  | (s) << 4 | (d), ((f) << 8) | ((i)&0xF),
+#define _ld_rii_32(s,i,f,d)   _MKOP(LD_RII_32)  | (s) << 4 | (d), ((f) << 8) | ((i)&0xF),
+#define _ld_rii_64(s,i,f,d)   _MKOP(LD_RII_64)  | (s) << 4 | (d), ((f) << 8) | ((i)&0xF),
 
 // Ignores the actual symbol indicator and inserts an unresolved symbol ID
-#define _ld_8_unresolved(x,d)            _MKOP(LD_8)|(d), 0xFFFF,
-#define _ld_16_unresolved(x,d)           _MKOP(LD_16)|(d), 0xFFFF,
-#define _ld_32_unresolved(x,d)           _MKOP(LD_32)|(d), 0xFFFF,
-#define _ld_64_unresolved(x,d)           _MKOP(LD_64)|(d), 0xFFFF,
-#define _lda_unresolved(x,d)             _MKOP(LD_ADDR)|(d), 0xFFFF,
+#define _ld_8_unresolved(x,d)            _MKOP(LD_8)    | 0xF0 | (d), 0xFFFF,
+#define _ld_16_unresolved(x,d)           _MKOP(LD_16)   | 0xF0 | (d), 0xFFFF,
+#define _ld_32_unresolved(x,d)           _MKOP(LD_32)   | 0xF0 | (d), 0xFFFF,
+#define _ld_64_unresolved(x,d)           _MKOP(LD_64)   | 0xF0 | (d), 0xFFFF,
+#define _lda_unresolved(x,d)             _MKOP(LD_ADDR) | 0xF0 | (d), 0xFFFF,
 
 // For testing mock resolved symbols
-#define _ld_8(x,d)            _MKOP(LD_8)|(d), (uint16)_SYM_DATA(x),
-#define _ld_16(x,d)           _MKOP(LD_16)|(d), (uint16)_SYM_DATA(x),
-#define _ld_32(x,d)           _MKOP(LD_32)|(d), (uint16)_SYM_DATA(x),
-#define _ld_64(x,d)           _MKOP(LD_64)|(d), (uint16)_SYM_DATA(x),
-#define _lda(x,d)             _MKOP(LD_ADDR)|(d), (uint16)_SYM_DATA(x),
+#define _ld_8(x,d)            _MKOP(LD_8)    | _SYM_DATA_UPPER(x) | (d), _SYM_DATA_LOWER(x),
+#define _ld_16(x,d)           _MKOP(LD_16)   | _SYM_DATA_UPPER(x) | (d), _SYM_DATA_LOWER(x),
+#define _ld_32(x,d)           _MKOP(LD_32)   | _SYM_DATA_UPPER(x) | (d), _SYM_DATA_LOWER(x),
+#define _ld_64(x,d)           _MKOP(LD_64)   | _SYM_DATA_UPPER(x) | (d), _SYM_DATA_LOWER(x),
+#define _lda(x,d)             _MKOP(LD_ADDR) | _SYM_DATA_UPPER(x) | (d), _SYM_DATA_LOWER(x),
 
-////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 //  store group
 //
@@ -260,55 +264,55 @@ inline uint16 _float32LSW(float32 f) {
 //  _operation(_rS, _rD, offset)     - indirect with displacement
 //  _operation(_rS, _rD, _rI, scale) - inirect scaled indexed
 //
-////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-#define _st_ri_8(s,d)         _MKOP(ST_RI_8)|(s)<<4|(d),
-#define _st_ri_16(s,d)        _MKOP(ST_RI_16)|(s)<<4|(d),
-#define _st_ri_32(s,d)        _MKOP(ST_RI_32)|(s)<<4|(d),
-#define _st_ri_64(s,d)        _MKOP(ST_RI_64)|(s)<<4|(d),
-#define _st_ripi_8(s,d)       _MKOP(ST_RIPI_8)|(s)<<4|(d),
-#define _st_ripi_16(s,d)      _MKOP(ST_RIPI_16)|(s)<<4|(d),
-#define _st_ripi_32(s,d)      _MKOP(ST_RIPI_32)|(s)<<4|(d),
-#define _st_ripi_64(s,d)      _MKOP(ST_RIPI_64)|(s)<<4|(d),
-#define _st_ripd_8(s,d)       _MKOP(ST_RIPD_8)|(s)<<4|(d),
-#define _st_ripd_16(s,d)      _MKOP(ST_RIPD_16)|(s)<<4|(d),
-#define _st_ripd_32(s,d)      _MKOP(ST_RIPD_32)|(s)<<4|(d),
-#define _st_ripd_64(s,d)      _MKOP(ST_RIPD_64)|(s)<<4|(d),
-#define _st_rid_8(s,d,o)      _MKOP(ST_RID_8)|(s)<<4|(d), (uint16)(o),
-#define _st_rid_16(s,d,o)     _MKOP(ST_RID_16)|(s)<<4|(d), (uint16)(o),
-#define _st_rid_32(s,d,o)     _MKOP(ST_RID_32)|(s)<<4|(d), (uint16)(o),
-#define _st_rid_64(s,d,o)     _MKOP(ST_RID_64)|(s)<<4|(d), (uint16)(o),
-#define _st_rii_8(s,d,i,f)    _MKOP(ST_RII_8)|(s)<<4|(d), ((f)<<8)|((i)&0xF),
-#define _st_rii_16(s,d,i,f)   _MKOP(ST_RII_16)|(s)<<4|(d), ((f)<<8)|((i)&0xF),
-#define _st_rii_32(s,d,i,f)   _MKOP(ST_RII_32)|(s)<<4|(d), ((f)<<8)|((i)&0xF),
-#define _st_rii_64(s,d,i,f)   _MKOP(ST_RII_64)|(s)<<4|(d), ((f)<<8)|((i)&0xF),
+#define _st_ri_8(s,d)         _MKOP(ST_RI_8)    | (s) << 4 | (d),
+#define _st_ri_16(s,d)        _MKOP(ST_RI_16)   | (s) << 4 | (d),
+#define _st_ri_32(s,d)        _MKOP(ST_RI_32)   | (s) << 4 | (d),
+#define _st_ri_64(s,d)        _MKOP(ST_RI_64)   | (s) << 4 | (d),
+#define _st_ripi_8(s,d)       _MKOP(ST_RIPI_8)  | (s) << 4 | (d),
+#define _st_ripi_16(s,d)      _MKOP(ST_RIPI_16) | (s) << 4 | (d),
+#define _st_ripi_32(s,d)      _MKOP(ST_RIPI_32) | (s) << 4 | (d),
+#define _st_ripi_64(s,d)      _MKOP(ST_RIPI_64) | (s) << 4 | (d),
+#define _st_ripd_8(s,d)       _MKOP(ST_RIPD_8)  | (s) << 4 | (d),
+#define _st_ripd_16(s,d)      _MKOP(ST_RIPD_16) | (s) << 4 | (d),
+#define _st_ripd_32(s,d)      _MKOP(ST_RIPD_32) | (s) << 4 | (d),
+#define _st_ripd_64(s,d)      _MKOP(ST_RIPD_64) | (s) << 4 | (d),
+#define _st_rid_8(s,d,o)      _MKOP(ST_RID_8)   | (s) << 4 | (d), (uint16)(o),
+#define _st_rid_16(s,d,o)     _MKOP(ST_RID_16)  | (s) << 4 | (d), (uint16)(o),
+#define _st_rid_32(s,d,o)     _MKOP(ST_RID_32)  | (s) << 4 | (d), (uint16)(o),
+#define _st_rid_64(s,d,o)     _MKOP(ST_RID_64)  | (s) << 4 | (d), (uint16)(o),
+#define _st_rii_8(s,d,i,f)    _MKOP(ST_RII_8)   | (s) << 4 | (d), ((f) << 8) | ((i)&0xF),
+#define _st_rii_16(s,d,i,f)   _MKOP(ST_RII_16)  | (s) << 4 | (d), ((f) << 8) | ((i)&0xF),
+#define _st_rii_32(s,d,i,f)   _MKOP(ST_RII_32)  | (s) << 4 | (d), ((f) << 8) | ((i)&0xF),
+#define _st_rii_64(s,d,i,f)   _MKOP(ST_RII_64)  | (s) << 4 | (d), ((f) << 8) | ((i)&0xF),
 
 // Ignores the actual symbol indicator and inserts an unresolved symbol ID
-#define _st_8_unresolved(s,x)            _MKOP(ST_8)|(s), (uint16)_SYM_DATA(x),
-#define _st_16_unresolved(s,x)           _MKOP(ST_16)|(s), (uint16)_SYM_DATA(x),
-#define _st_32_unresolved(s,x)           _MKOP(ST_32)|(s), (uint16)_SYM_DATA(x),
-#define _st_64_unresolved(s,x)           _MKOP(ST_64)|(s), (uint16)_SYM_DATA(x),
+#define _st_8_unresolved(s,x)            _MKOP(ST_8)  | 0xF0 | (s), 0xFFFF,
+#define _st_16_unresolved(s,x)           _MKOP(ST_16) | 0xF0 | (s), 0xFFFF,
+#define _st_32_unresolved(s,x)           _MKOP(ST_32) | 0xF0 | (s), 0xFFFF,
+#define _st_64_unresolved(s,x)           _MKOP(ST_64) | 0xF0 | (s), 0xFFFF,
 
 // For testing mock resolved symbols
-#define _st_8(s,x)            _MKOP(ST_8)|(s), (uint16)_SYM_DATA(x),
-#define _st_16(s,x)           _MKOP(ST_16)|(s), (uint16)_SYM_DATA(x),
-#define _st_32(s,x)           _MKOP(ST_32)|(s), (uint16)_SYM_DATA(x),
-#define _st_64(s,x)           _MKOP(ST_64)|(s), (uint16)_SYM_DATA(x),
+#define _st_8(s,x)            _MKOP(ST_8)  | _SYM_DATA_UPPER(x) | (s), _SYM_DATA_LOWER(x),
+#define _st_16(s,x)           _MKOP(ST_16) | _SYM_DATA_UPPER(x) | (s), _SYM_DATA_LOWER(x),
+#define _st_32(s,x)           _MKOP(ST_32) | _SYM_DATA_UPPER(x) | (s), _SYM_DATA_LOWER(x),
+#define _st_64(s,x)           _MKOP(ST_64) | _SYM_DATA_UPPER(x) | (s), _SYM_DATA_LOWER(x),
 
-////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 //  move group
 //
 //  _operation(_rS, rD)         - move, exg
 //  _operation(_r1|_r2|..._r16) - save, restore, push, pop
 //
-////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-#define _move_8(s,d)          _MKOP(MV_8)|(s)<<4|(d),
-#define _move_16(s,d)         _MKOP(MV_16)|(s)<<4|(d),
-#define _move_32(s,d)         _MKOP(MV_32)|(s)<<4|(d),
-#define _move_64(s,d)         _MKOP(MV_64)|(s)<<4|(d),
-#define _exg(s,d)             _MKOP(EXG)|(s)<<4|(d),
+#define _move_8(s,d)          _MKOP(MV_8)  | (s) << 4 | (d),
+#define _move_16(s,d)         _MKOP(MV_16) | (s) << 4 | (d),
+#define _move_32(s,d)         _MKOP(MV_32) | (s) << 4 | (d),
+#define _move_64(s,d)         _MKOP(MV_64) | (s) << 4 | (d),
+#define _exg(s,d)             _MKOP(EXG)   | (s) << 4 | (d),
 #define _save(m)              _MKOP(SV), (m),
 #define _restore(m)           _MKOP(RS), (m),
 #define _push_8(m)            _MKOP(PUSH_8), (m),
@@ -320,14 +324,14 @@ inline uint16 _float32LSW(float32 f) {
 #define _pop_32(m)            _MKOP(POP_32), (m),
 #define _pop_64(m)            _MKOP(POP_64), (m),
 
-////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 //  jump group
 //
 //  _operation(label)            - bra, call, calln
 //  _operation(_rS, _rD, offset) - bxx
 //
-////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 
 #define _bcall_8_unresolved(x) _MKOP(CALL), 0xFFFF,
@@ -343,218 +347,218 @@ inline uint16 _float32LSW(float32 f) {
 #define _calln(x)             _MKOP(CALLN), (uint16)_SYM_NATIVE(x),
 
 #define _ret                  _MKOP(RET)
-#define _bra_8(o)             _MKOP(BRA8)|(o),
+#define _bra_8(o)             _MKOP(BRA8) | (o),
 #define _bra(o)               _MKOP(BRA16), (uint16)(o),
-#define _case(r,sz)           _MKOP(CASE)|(r), (sz),
+#define _case(r,sz)           _MKOP(CASE) | (r), (sz),
 
-#define _bnz_8(r,o)           _MKOP(BNZ_8)|(r), (uint16)(o),
-#define _bnz_16(r,o)          _MKOP(BNZ_16)|(r), (uint16)(o),
-#define _bnz_32(r,o)          _MKOP(BNZ_32)|(r), (uint16)(o),
-#define _bnz_64(r,o)          _MKOP(BNZ_64)|(r), (uint16)(o),
+#define _bnz_8(r,o)           _MKOP(BNZ_8)  | (r), (uint16)(o),
+#define _bnz_16(r,o)          _MKOP(BNZ_16) | (r), (uint16)(o),
+#define _bnz_32(r,o)          _MKOP(BNZ_32) | (r), (uint16)(o),
+#define _bnz_64(r,o)          _MKOP(BNZ_64) | (r), (uint16)(o),
 
 // Fake Less a < b based on b > a
-#define _bls_8(s,d,o)         _MKOP(BGR_8)|(d)<<4|(s), (uint16)(o),
-#define _bls_16(s,d,o)        _MKOP(BGR_16)|(d)<<4|(s), (uint16)(o),
-#define _bls_32(s,d,o)        _MKOP(BGR_32)|(d)<<4|(s), (uint16)(o),
-#define _bls_64(s,d,o)        _MKOP(BGR_64)|(d)<<4|(s), (uint16)(o),
-#define _bls_f32(s,d,o)       _MKOP(BGR_F32)|(d)<<4|(s), (uint16)(o),
-#define _bls_f64(s,d,o)       _MKOP(BGR_F64)|(d)<<4|(s), (uint16)(o),
-#define _blseq_8(s,d,o)       _MKOP(BGREQ_8)|(d)<<4|(s), (uint16)(o),
-#define _blseq_16(s,d,o)      _MKOP(BGREQ_16)|(d)<<4|(s), (uint16)(o),
-#define _blseq_32(s,d,o)      _MKOP(BGREQ_32)|(d)<<4|(s), (uint16)(o),
-#define _blseq_64(s,d,o)      _MKOP(BGREQ_64)|(d)<<4|(s), (uint16)(o),
-#define _blseq_f32(s,d,o)     _MKOP(BGREQ_F32)|(d)<<4|(s), (uint16)(o),
-#define _blseq_f64(s,d,o)     _MKOP(BGREQ_F64)|(d)<<4|(s), (uint16)(o),
+#define _bls_8(s,d,o)         _MKOP(BGR_8)     | (d) << 4 | (s), (uint16)(o),
+#define _bls_16(s,d,o)        _MKOP(BGR_16)    | (d) << 4 | (s), (uint16)(o),
+#define _bls_32(s,d,o)        _MKOP(BGR_32)    | (d) << 4 | (s), (uint16)(o),
+#define _bls_64(s,d,o)        _MKOP(BGR_64)    | (d) << 4 | (s), (uint16)(o),
+#define _bls_f32(s,d,o)       _MKOP(BGR_F32)   | (d) << 4 | (s), (uint16)(o),
+#define _bls_f64(s,d,o)       _MKOP(BGR_F64)   | (d) << 4 | (s), (uint16)(o),
+#define _blseq_8(s,d,o)       _MKOP(BGREQ_8)   | (d) << 4 | (s), (uint16)(o),
+#define _blseq_16(s,d,o)      _MKOP(BGREQ_16)  | (d) << 4 | (s), (uint16)(o),
+#define _blseq_32(s,d,o)      _MKOP(BGREQ_32)  | (d) << 4 | (s), (uint16)(o),
+#define _blseq_64(s,d,o)      _MKOP(BGREQ_64)  | (d) << 4 | (s), (uint16)(o),
+#define _blseq_f32(s,d,o)     _MKOP(BGREQ_F32) | (d) << 4 | (s), (uint16)(o),
+#define _blseq_f64(s,d,o)     _MKOP(BGREQ_F64) | (d) << 4 | (s), (uint16)(o),
 
-#define _beq_8(s,d,o)         _MKOP(BEQ_8)|(s)<<4|(d), (uint16)(o),
-#define _beq_16(s,d,o)        _MKOP(BEQ_16)|(s)<<4|(d), (uint16)(o),
-#define _beq_32(s,d,o)        _MKOP(BEQ_32)|(s)<<4|(d), (uint16)(o),
-#define _beq_64(s,d,o)        _MKOP(BEQ_64)|(s)<<4|(d), (uint16)(o),
-#define _beq_f32(s,d,o)       _MKOP(BEQ_F32)|(s)<<4|(d), (uint16)(o),
-#define _beq_f64(s,d,o)       _MKOP(BEQ_F64)|(s)<<4|(d), (uint16)(o),
-#define _bgreq_8(s,d,o)       _MKOP(BGREQ_8)|(s)<<4|(d), (uint16)(o),
-#define _bgreq_16(s,d,o)      _MKOP(BGREQ_16)|(s)<<4|(d), (uint16)(o),
-#define _bgreq_32(s,d,o)      _MKOP(BGREQ_32)|(s)<<4|(d), (uint16)(o),
-#define _bgreq_64(s,d,o)      _MKOP(BGREQ_64)|(s)<<4|(d), (uint16)(o),
-#define _bgreq_f32(s,d,o)     _MKOP(BGREQ_F32)|(s)<<4|(d), (uint16)(o),
-#define _bgreq_f64(s,d,o)     _MKOP(BGREQ_F64)|(s)<<4|(d), (uint16)(o),
-#define _bgr_8(s,d,o)         _MKOP(BGR_8)|(s)<<4|(d), (uint16)(o),
-#define _bgr_16(s,d,o)        _MKOP(BGR_16)|(s)<<4|(d), (uint16)(o),
-#define _bgr_32(s,d,o)        _MKOP(BGR_32)|(s)<<4|(d), (uint16)(o),
-#define _bgr_64(s,d,o)        _MKOP(BGR_64)|(s)<<4|(d), (uint16)(o),
-#define _bgr_f32(s,d,o)       _MKOP(BGR_F32)|(s)<<4|(d), (uint16)(o),
-#define _bgr_f64(s,d,o)       _MKOP(BGR_F64)|(s)<<4|(d), (uint16)(o),
+#define _beq_8(s,d,o)         _MKOP(BEQ_8)     | (s) << 4 | (d), (uint16)(o),
+#define _beq_16(s,d,o)        _MKOP(BEQ_16)    | (s) << 4 | (d), (uint16)(o),
+#define _beq_32(s,d,o)        _MKOP(BEQ_32)    | (s) << 4 | (d), (uint16)(o),
+#define _beq_64(s,d,o)        _MKOP(BEQ_64)    | (s) << 4 | (d), (uint16)(o),
+#define _beq_f32(s,d,o)       _MKOP(BEQ_F32)   | (s) << 4 | (d), (uint16)(o),
+#define _beq_f64(s,d,o)       _MKOP(BEQ_F64)   | (s) << 4 | (d), (uint16)(o),
+#define _bgreq_8(s,d,o)       _MKOP(BGREQ_8)   | (s) << 4 | (d), (uint16)(o),
+#define _bgreq_16(s,d,o)      _MKOP(BGREQ_16)  | (s) << 4 | (d), (uint16)(o),
+#define _bgreq_32(s,d,o)      _MKOP(BGREQ_32)  | (s) << 4 | (d), (uint16)(o),
+#define _bgreq_64(s,d,o)      _MKOP(BGREQ_64)  | (s) << 4 | (d), (uint16)(o),
+#define _bgreq_f32(s,d,o)     _MKOP(BGREQ_F32) | (s) << 4 | (d), (uint16)(o),
+#define _bgreq_f64(s,d,o)     _MKOP(BGREQ_F64) | (s) << 4 | (d), (uint16)(o),
+#define _bgr_8(s,d,o)         _MKOP(BGR_8)     | (s) << 4 | (d), (uint16)(o),
+#define _bgr_16(s,d,o)        _MKOP(BGR_16)    | (s) << 4 | (d), (uint16)(o),
+#define _bgr_32(s,d,o)        _MKOP(BGR_32)    | (s) << 4 | (d), (uint16)(o),
+#define _bgr_64(s,d,o)        _MKOP(BGR_64)    | (s) << 4 | (d), (uint16)(o),
+#define _bgr_f32(s,d,o)       _MKOP(BGR_F32)   | (s) << 4 | (d), (uint16)(o),
+#define _bgr_f64(s,d,o)       _MKOP(BGR_F64)   | (s) << 4 | (d), (uint16)(o),
 
-////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 //  conversion group
 //
 //  _operation(_rS, _rD)
 //
-////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-#define _s8to_s16(s,d)        _MKOP(S8_2_S16)|(s)<<4|(d),
-#define _s8to_s32(s,d)        _MKOP(S8_2_S32)|(s)<<4|(d),
-#define _s8to_s64(s,d)        _MKOP(S8_2_S64)|(s)<<4|(d),
-#define _s8to_f32(s,d)        _MKOP(S8_2_F32)|(s)<<4|(d),
-#define _s8to_f64(s,d)        _MKOP(S8_2_F64)|(s)<<4|(d),
-#define _s16to_s32(s,d)       _MKOP(S16_2_S32)|(s)<<4|(d),
-#define _s16to_s64(s,d)       _MKOP(S16_2_S64)|(s)<<4|(d),
-#define _s16to_f32(s,d)       _MKOP(S16_2_F32)|(s)<<4|(d),
-#define _s16to_f64(s,d)       _MKOP(S16_2_F64)|(s)<<4|(d),
-#define _s32to_s64(s,d)       _MKOP(S32_2_S64)|(s)<<4|(d),
-#define _s32to_f32(s,d)       _MKOP(S32_2_F32)|(s)<<4|(d),
-#define _s32to_f64(s,d)       _MKOP(S32_2_F64)|(s)<<4|(d),
-#define _s64to_f32(s,d)       _MKOP(S64_2_F32)|(s)<<4|(d),
-#define _s64to_f64(s,d)       _MKOP(S64_2_F64)|(s)<<4|(d),
-#define _u8to_f32(s,d)        _MKOP(U8_2_F32)|(s)<<4|(d),
-#define _u8to_f64(s,d)        _MKOP(U8_2_F64)|(s)<<4|(d),
-#define _u16to_f32(s,d)       _MKOP(U16_2_F32)|(s)<<4|(d),
-#define _u16to_f64(s,d)       _MKOP(U16_2_F64)|(s)<<4|(d),
-#define _u32to_f32(s,d)       _MKOP(U32_2_F32)|(s)<<4|(d),
-#define _u32to_f64(s,d)       _MKOP(U32_2_F64)|(s)<<4|(d),
-#define _u64to_f32(s,d)       _MKOP(U64_2_F32)|(s)<<4|(d),
-#define _u64to_f64(s,d)       _MKOP(U64_2_F64)|(s)<<4|(d),
-#define _f32to_f64(s,d)       _MKOP(F32_2_F64)|(s)<<4|(d),
-#define _f64to_f32(s,d)       _MKOP(F64_2_F32)|(s)<<4|(d),
-#define _f64to_s64(s,d)       _MKOP(F64_2_S64)|(s)<<4|(d),
-#define _f64to_s32(s,d)       _MKOP(F64_2_S32)|(s)<<4|(d),
-#define _f64to_s16(s,d)       _MKOP(F64_2_S16)|(s)<<4|(d),
-#define _f64to_s8(s,d)        _MKOP(F64_2_S8)|(s)<<4|(d),
-#define _f32to_s64(s,d)       _MKOP(F32_2_S64)|(s)<<4|(d),
-#define _f32to_s32(s,d)       _MKOP(F32_2_S32)|(s)<<4|(d),
-#define _f32to_s16(s,d)       _MKOP(F32_2_S16)|(s)<<4|(d),
-#define _f32to_s8(s,d)        _MKOP(F32_2_S8)|(s)<<4|(d),
+#define _s8to_s16(s,d)        _MKOP(S8_2_S16)  | (s) << 4 | (d),
+#define _s8to_s32(s,d)        _MKOP(S8_2_S32)  | (s) << 4 | (d),
+#define _s8to_s64(s,d)        _MKOP(S8_2_S64)  | (s) << 4 | (d),
+#define _s8to_f32(s,d)        _MKOP(S8_2_F32)  | (s) << 4 | (d),
+#define _s8to_f64(s,d)        _MKOP(S8_2_F64)  | (s) << 4 | (d),
+#define _s16to_s32(s,d)       _MKOP(S16_2_S32) | (s) << 4 | (d),
+#define _s16to_s64(s,d)       _MKOP(S16_2_S64) | (s) << 4 | (d),
+#define _s16to_f32(s,d)       _MKOP(S16_2_F32) | (s) << 4 | (d),
+#define _s16to_f64(s,d)       _MKOP(S16_2_F64) | (s) << 4 | (d),
+#define _s32to_s64(s,d)       _MKOP(S32_2_S64) | (s) << 4 | (d),
+#define _s32to_f32(s,d)       _MKOP(S32_2_F32) | (s) << 4 | (d),
+#define _s32to_f64(s,d)       _MKOP(S32_2_F64) | (s) << 4 | (d),
+#define _s64to_f32(s,d)       _MKOP(S64_2_F32) | (s) << 4 | (d),
+#define _s64to_f64(s,d)       _MKOP(S64_2_F64) | (s) << 4 | (d),
+#define _u8to_f32(s,d)        _MKOP(U8_2_F32)  | (s) << 4 | (d),
+#define _u8to_f64(s,d)        _MKOP(U8_2_F64)  | (s) << 4 | (d),
+#define _u16to_f32(s,d)       _MKOP(U16_2_F32) | (s) << 4 | (d),
+#define _u16to_f64(s,d)       _MKOP(U16_2_F64) | (s) << 4 | (d),
+#define _u32to_f32(s,d)       _MKOP(U32_2_F32) | (s) << 4 | (d),
+#define _u32to_f64(s,d)       _MKOP(U32_2_F64) | (s) << 4 | (d),
+#define _u64to_f32(s,d)       _MKOP(U64_2_F32) | (s) << 4 | (d),
+#define _u64to_f64(s,d)       _MKOP(U64_2_F64) | (s) << 4 | (d),
+#define _f32to_f64(s,d)       _MKOP(F32_2_F64) | (s) << 4 | (d),
+#define _f64to_f32(s,d)       _MKOP(F64_2_F32) | (s) << 4 | (d),
+#define _f64to_s64(s,d)       _MKOP(F64_2_S64) | (s) << 4 | (d),
+#define _f64to_s32(s,d)       _MKOP(F64_2_S32) | (s) << 4 | (d),
+#define _f64to_s16(s,d)       _MKOP(F64_2_S16) | (s) << 4 | (d),
+#define _f64to_s8(s,d)        _MKOP(F64_2_S8)  | (s) << 4 | (d),
+#define _f32to_s64(s,d)       _MKOP(F32_2_S64) | (s) << 4 | (d),
+#define _f32to_s32(s,d)       _MKOP(F32_2_S32) | (s) << 4 | (d),
+#define _f32to_s16(s,d)       _MKOP(F32_2_S16) | (s) << 4 | (d),
+#define _f32to_s8(s,d)        _MKOP(F32_2_S8)  | (s) << 4 | (d),
 
-////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 //  arithmetic group
 //
 //  _operation(_rS, _rD)
 //
-////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-#define _add_8(s,d)           _MKOP(ADD_I8)|(s)<<4|(d),
-#define _add_16(s,d)          _MKOP(ADD_I16)|(s)<<4|(d),
-#define _add_32(s,d)          _MKOP(ADD_I32)|(s)<<4|(d),
-#define _add_64(s,d)          _MKOP(ADD_I64)|(s)<<4|(d),
-#define _add_f32(s,d)         _MKOP(ADD_F32)|(s)<<4|(d),
-#define _add_f64(s,d)         _MKOP(ADD_F64)|(s)<<4|(d),
-#define _addi_8(n,r)          _MKOP(ADDI_I8)|(r), (n),
-#define _addi_16(n,r)         _MKOP(ADDI_I16)|(r), (n),
-#define _addi_32(n,r)         _MKOP(ADDI_I32)|(r), _INLINE32(n),
-#define _sub_8(s,d)           _MKOP(SUB_I8)|(s)<<4|(d),
-#define _sub_16(s,d)          _MKOP(SUB_I16)|(s)<<4|(d),
-#define _sub_32(s,d)          _MKOP(SUB_I32)|(s)<<4|(d),
-#define _sub_64(s,d)          _MKOP(SUB_I64)|(s)<<4|(d),
-#define _sub_f32(s,d)         _MKOP(SUB_F32)|(s)<<4|(d),
-#define _sub_f64(s,d)         _MKOP(SUB_F64)|(s)<<4|(d),
-#define _subi_8(n,r)          _MKOP(ADDI_I8)|(r), (uint16)(-(n)),
-#define _subi_16(n,r)         _MKOP(ADDI_I16)|(r), (uint16)(-(n)),
-#define _subi_32(n,r)         _MKOP(ADDI_I32)|(r), _INLINE32(-(n)),
-#define _mul_u8(s,d)          _MKOP(MUL_U8)|(s)<<4|(d),
-#define _mul_u16(s,d)         _MKOP(MUL_U16)|(s)<<4|(d),
-#define _mul_u32(s,d)         _MKOP(MUL_U32)|(s)<<4|(d),
-#define _mul_u64(s,d)         _MKOP(MUL_U64)|(s)<<4|(d),
-#define _mul_s8(s,d)          _MKOP(MUL_S8)|(s)<<4|(d),
-#define _mul_s16(s,d)         _MKOP(MUL_S16)|(s)<<4|(d),
-#define _mul_s32(s,d)         _MKOP(MUL_S32)|(s)<<4|(d),
-#define _mul_s64(s,d)         _MKOP(MUL_S64)|(s)<<4|(d),
-#define _mul_f32(s,d)         _MKOP(MUL_F32)|(s)<<4|(d),
-#define _mul_f64(s,d)         _MKOP(MUL_F64)|(s)<<4|(d),
-#define _div_u8(s,d)          _MKOP(DIV_U8)|(s)<<4|(d),
-#define _div_u16(s,d)         _MKOP(DIV_U16)|(s)<<4|(d),
-#define _div_u32(s,d)         _MKOP(DIV_U32)|(s)<<4|(d),
-#define _div_u64(s,d)         _MKOP(DIV_U64)|(s)<<4|(d),
-#define _div_s8(s,d)          _MKOP(DIV_S8)|(s)<<4|(d),
-#define _div_s16(s,d)         _MKOP(DIV_S16)|(s)<<4|(d),
-#define _div_s32(s,d)         _MKOP(DIV_S32)|(s)<<4|(d),
-#define _div_s64(s,d)         _MKOP(DIV_S64)|(s)<<4|(d),
-#define _div_f32(s,d)         _MKOP(DIV_F32)|(s)<<4|(d),
-#define _div_f64(s,d)         _MKOP(DIV_F64)|(s)<<4|(d),
-#define _mod_u8(s,d)          _MKOP(MOD_U8)|(s)<<4|(d),
-#define _mod_u16(s,d)         _MKOP(MOD_U16)|(s)<<4|(d),
-#define _mod_u32(s,d)         _MKOP(MOD_U32)|(s)<<4|(d),
-#define _mod_u64(s,d)         _MKOP(MOD_U64)|(s)<<4|(d),
-#define _mod_s8(s,d)          _MKOP(MOD_S8)|(s)<<4|(d),
-#define _mod_s15(s,d)         _MKOP(MOD_S16)|(s)<<4|(d),
-#define _mod_s32(s,d)         _MKOP(MOD_S32)|(s)<<4|(d),
-#define _mod_s64(s,d)         _MKOP(MOD_S64)|(s)<<4|(d),
-#define _mod_f32(s,d)         _MKOP(MOD_F32)|(s)<<4|(d),
-#define _mod_f64(s,d)         _MKOP(MOD_F64)|(s)<<4|(d),
-#define _neg_s8(s,d)          _MKOP(NEG_S8)|(s)<<4|(d),
-#define _neg_s16(s,d)         _MKOP(NEG_S16)|(s)<<4|(d),
-#define _neg_s32(s,d)         _MKOP(NEG_S32)|(s)<<4|(d),
-#define _neg_s64(s,d)         _MKOP(NEG_S64)|(s)<<4|(d),
-#define _neg_f32(s,d)         _MKOP(NEG_F32)|(s)<<4|(d),
-#define _neg_f64(s,d)         _MKOP(NEG_F64)|(s)<<4|(d),
+#define _add_8(s,d)           _MKOP(ADD_I8)   | (s) << 4 | (d),
+#define _add_16(s,d)          _MKOP(ADD_I16)  | (s) << 4 | (d),
+#define _add_32(s,d)          _MKOP(ADD_I32)  | (s) << 4 | (d),
+#define _add_64(s,d)          _MKOP(ADD_I64)  | (s) << 4 | (d),
+#define _add_f32(s,d)         _MKOP(ADD_F32)  | (s) << 4 | (d),
+#define _add_f64(s,d)         _MKOP(ADD_F64)  | (s) << 4 | (d),
+#define _addi_8(n,r)          _MKOP(ADDI_I8)  | (r), (n),
+#define _addi_16(n,r)         _MKOP(ADDI_I16) | (r), (n),
+#define _addi_32(n,r)         _MKOP(ADDI_I32) | (r), _INLINE32(n),
+#define _sub_8(s,d)           _MKOP(SUB_I8)   | (s) << 4 | (d),
+#define _sub_16(s,d)          _MKOP(SUB_I16)  | (s) << 4 | (d),
+#define _sub_32(s,d)          _MKOP(SUB_I32)  | (s) << 4 | (d),
+#define _sub_64(s,d)          _MKOP(SUB_I64)  | (s) << 4 | (d),
+#define _sub_f32(s,d)         _MKOP(SUB_F32)  | (s) << 4 | (d),
+#define _sub_f64(s,d)         _MKOP(SUB_F64)  | (s) << 4 | (d),
+#define _subi_8(n,r)          _MKOP(ADDI_I8)  | (r), (uint16)(-(n)),
+#define _subi_16(n,r)         _MKOP(ADDI_I16) | (r), (uint16)(-(n)),
+#define _subi_32(n,r)         _MKOP(ADDI_I32) | (r), _INLINE32(-(n)),
+#define _mul_u8(s,d)          _MKOP(MUL_U8)   | (s) << 4 | (d),
+#define _mul_u16(s,d)         _MKOP(MUL_U16)  | (s) << 4 | (d),
+#define _mul_u32(s,d)         _MKOP(MUL_U32)  | (s) << 4 | (d),
+#define _mul_u64(s,d)         _MKOP(MUL_U64)  | (s) << 4 | (d),
+#define _mul_s8(s,d)          _MKOP(MUL_S8)   | (s) << 4 | (d),
+#define _mul_s16(s,d)         _MKOP(MUL_S16)  | (s) << 4 | (d),
+#define _mul_s32(s,d)         _MKOP(MUL_S32)  | (s) << 4 | (d),
+#define _mul_s64(s,d)         _MKOP(MUL_S64)  | (s) << 4 | (d),
+#define _mul_f32(s,d)         _MKOP(MUL_F32)  | (s) << 4 | (d),
+#define _mul_f64(s,d)         _MKOP(MUL_F64)  | (s) << 4 | (d),
+#define _div_u8(s,d)          _MKOP(DIV_U8)   | (s) << 4 | (d),
+#define _div_u16(s,d)         _MKOP(DIV_U16)  | (s) << 4 | (d),
+#define _div_u32(s,d)         _MKOP(DIV_U32)  | (s) << 4 | (d),
+#define _div_u64(s,d)         _MKOP(DIV_U64)  | (s) << 4 | (d),
+#define _div_s8(s,d)          _MKOP(DIV_S8)   | (s) << 4 | (d),
+#define _div_s16(s,d)         _MKOP(DIV_S16)  | (s) << 4 | (d),
+#define _div_s32(s,d)         _MKOP(DIV_S32)  | (s) << 4 | (d),
+#define _div_s64(s,d)         _MKOP(DIV_S64)  | (s) << 4 | (d),
+#define _div_f32(s,d)         _MKOP(DIV_F32)  | (s) << 4 | (d),
+#define _div_f64(s,d)         _MKOP(DIV_F64)  | (s) << 4 | (d),
+#define _mod_u8(s,d)          _MKOP(MOD_U8)   | (s) << 4 | (d),
+#define _mod_u16(s,d)         _MKOP(MOD_U16)  | (s) << 4 | (d),
+#define _mod_u32(s,d)         _MKOP(MOD_U32)  | (s) << 4 | (d),
+#define _mod_u64(s,d)         _MKOP(MOD_U64)  | (s) << 4 | (d),
+#define _mod_s8(s,d)          _MKOP(MOD_S8)   | (s) << 4 | (d),
+#define _mod_s15(s,d)         _MKOP(MOD_S16)  | (s) << 4 | (d),
+#define _mod_s32(s,d)         _MKOP(MOD_S32)  | (s) << 4 | (d),
+#define _mod_s64(s,d)         _MKOP(MOD_S64)  | (s) << 4 | (d),
+#define _mod_f32(s,d)         _MKOP(MOD_F32)  | (s) << 4 | (d),
+#define _mod_f64(s,d)         _MKOP(MOD_F64)  | (s) << 4 | (d),
+#define _neg_s8(s,d)          _MKOP(NEG_S8)   | (s) << 4 | (d),
+#define _neg_s16(s,d)         _MKOP(NEG_S16)  | (s) << 4 | (d),
+#define _neg_s32(s,d)         _MKOP(NEG_S32)  | (s) << 4 | (d),
+#define _neg_s64(s,d)         _MKOP(NEG_S64)  | (s) << 4 | (d),
+#define _neg_f32(s,d)         _MKOP(NEG_F32)  | (s) << 4 | (d),
+#define _neg_f64(s,d)         _MKOP(NEG_F64)  | (s) << 4 | (d),
 
-#define _asr_s8(s,d)          _MKOP(ASR_S8)|(s)<<4|(d),
-#define _asr_s16(s,d)         _MKOP(ASR_S16)|(s)<<4|(d),
-#define _asr_s32(s,d)         _MKOP(ASR_S32)|(s)<<4|(d),
-#define _asr_s64(s,d)         _MKOP(ASR_S64)|(s)<<4|(d),
-#define _min_s8(s,d)          _MKOP(MIN_S8)|(s)<<4|(d),
-#define _min_s16(s,d)         _MKOP(MIN_S16)|(s)<<4|(d),
-#define _min_s32(s,d)         _MKOP(MIN_S32)|(s)<<4|(d),
-#define _min_s64(s,d)         _MKOP(MIN_S64)|(s)<<4|(d),
-#define _min_f32(s,d)         _MKOP(MIN_F32)|(s)<<4|(d),
-#define _min_f64(s,d)         _MKOP(MIN_F64)|(s)<<4|(d),
-#define _max_s8(s,d)          _MKOP(MAX_S8)|(s)<<4|(d),
-#define _max_s16(s,d)         _MKOP(MAX_S16)|(s)<<4|(d),
-#define _max_s32(s,d)         _MKOP(MAX_S32)|(s)<<4|(d),
-#define _max_s64(s,d)         _MKOP(MAX_S64)|(s)<<4|(d),
-#define _max_f32(s,d)         _MKOP(MAX_F32)|(s)<<4|(d),
-#define _max_f64(s,d)         _MKOP(MAX_F64)|(s)<<4|(d),
+#define _asr_s8(s,d)          _MKOP(ASR_S8)   | (s) << 4 | (d),
+#define _asr_s16(s,d)         _MKOP(ASR_S16)  | (s) << 4 | (d),
+#define _asr_s32(s,d)         _MKOP(ASR_S32)  | (s) << 4 | (d),
+#define _asr_s64(s,d)         _MKOP(ASR_S64)  | (s) << 4 | (d),
+#define _min_s8(s,d)          _MKOP(MIN_S8)   | (s) << 4 | (d),
+#define _min_s16(s,d)         _MKOP(MIN_S16)  | (s) << 4 | (d),
+#define _min_s32(s,d)         _MKOP(MIN_S32)  | (s) << 4 | (d),
+#define _min_s64(s,d)         _MKOP(MIN_S64)  | (s) << 4 | (d),
+#define _min_f32(s,d)         _MKOP(MIN_F32)  | (s) << 4 | (d),
+#define _min_f64(s,d)         _MKOP(MIN_F64)  | (s) << 4 | (d),
+#define _max_s8(s,d)          _MKOP(MAX_S8)   | (s) << 4 | (d),
+#define _max_s16(s,d)         _MKOP(MAX_S16)  | (s) << 4 | (d),
+#define _max_s32(s,d)         _MKOP(MAX_S32)  | (s) << 4 | (d),
+#define _max_s64(s,d)         _MKOP(MAX_S64)  | (s) << 4 | (d),
+#define _max_f32(s,d)         _MKOP(MAX_F32)  | (s) << 4 | (d),
+#define _max_f64(s,d)         _MKOP(MAX_F64)  | (s) << 4 | (d),
 
-////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 //  logic group
 //
 //  _operation(_rS, _rD)
 //
-////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-#define _and_8(s,d)           _MKOP(AND_8)|(s)<<4|(d),
-#define _and_16(s,d)          _MKOP(AND_16)|(s)<<4|(d),
-#define _and_32(s,d)          _MKOP(AND_32)|(s)<<4|(d),
-#define _and_64(s,d)          _MKOP(AND_64)|(s)<<4|(d),
-#define _or_8(s,d)            _MKOP(OR_8)|(s)<<4|(d),
-#define _or_16(s,d)           _MKOP(OR_16)|(s)<<4|(d),
-#define _or_32(s,d)           _MKOP(OR_32)|(s)<<4|(d),
-#define _or_64(s,d)           _MKOP(OR_64)|(s)<<4|(d),
-#define _xor_8(s,d)           _MKOP(XOR_8)|(s)<<4|(d),
-#define _xor_16(s,d)          _MKOP(XOR_16)|(s)<<4|(d),
-#define _xor_32(s,d)          _MKOP(XOR_32)|(s)<<4|(d),
-#define _xor_64(s,d)          _MKOP(XOR_64)|(s)<<4|(d),
-#define _inv_8(s,d)           _MKOP(INV_8)|(s)<<4|(d),
-#define _inv_16(s,d)          _MKOP(INV_16)|(s)<<4|(d),
-#define _inv_32(s,d)          _MKOP(INV_32)|(s)<<4|(d),
-#define _inv_64(s,d)          _MKOP(INV_64)|(s)<<4|(d),
-#define _lsl_8(s,d)           _MKOP(LSL_8)|(s)<<4|(d),
-#define _lsl_16(s,d)          _MKOP(LSL_16)|(s)<<4|(d),
-#define _lsl_32(s,d)          _MKOP(LSL_32)|(s)<<4|(d),
-#define _lsl_64(s,d)          _MKOP(LSL_64)|(s)<<4|(d),
-#define _lsr_8(s,d)           _MKOP(LSR_8)|(s)<<4|(d),
-#define _lsr_16(s,d)          _MKOP(LSR_16)|(s)<<4|(d),
-#define _lsr_32(s,d)          _MKOP(LSR_32)|(s)<<4|(d),
-#define _lsr_64(s,d)          _MKOP(LSR_64)|(s)<<4|(d),
-#define _rol_8(s,d)           _MKOP(ROL_8)|(s)<<4|(d),
-#define _rol_16(s,d)          _MKOP(ROL_16)|(s)<<4|(d),
-#define _rol_32(s,d)          _MKOP(ROL_32)|(s)<<4|(d),
-#define _rol_64(s,d)          _MKOP(ROL_64)|(s)<<4|(d),
-#define _ror_8(s,d)           _MKOP(ROR_8)|(s)<<4|(d),
-#define _ror_16(s,d)          _MKOP(ROR_16)|(s)<<4|(d),
-#define _ror_32(s,d)          _MKOP(ROR_32)|(s)<<4|(d),
-#define _ror_64(s,d)          _MKOP(ROR_64)|(s)<<4|(d),
+#define _and_8(s,d)           _MKOP(AND_8)  | (s) << 4 | (d),
+#define _and_16(s,d)          _MKOP(AND_16) | (s) << 4 | (d),
+#define _and_32(s,d)          _MKOP(AND_32) | (s) << 4 | (d),
+#define _and_64(s,d)          _MKOP(AND_64) | (s) << 4 | (d),
+#define _or_8(s,d)            _MKOP(OR_8)   | (s) << 4 | (d),
+#define _or_16(s,d)           _MKOP(OR_16)  | (s) << 4 | (d),
+#define _or_32(s,d)           _MKOP(OR_32)  | (s) << 4 | (d),
+#define _or_64(s,d)           _MKOP(OR_64)  | (s) << 4 | (d),
+#define _xor_8(s,d)           _MKOP(XOR_8)  | (s) << 4 | (d),
+#define _xor_16(s,d)          _MKOP(XOR_16) | (s) << 4 | (d),
+#define _xor_32(s,d)          _MKOP(XOR_32) | (s) << 4 | (d),
+#define _xor_64(s,d)          _MKOP(XOR_64) | (s) << 4 | (d),
+#define _inv_8(s,d)           _MKOP(INV_8)  | (s) << 4 | (d),
+#define _inv_16(s,d)          _MKOP(INV_16) | (s) << 4 | (d),
+#define _inv_32(s,d)          _MKOP(INV_32) | (s) << 4 | (d),
+#define _inv_64(s,d)          _MKOP(INV_64) | (s) << 4 | (d),
+#define _lsl_8(s,d)           _MKOP(LSL_8)  | (s) << 4 | (d),
+#define _lsl_16(s,d)          _MKOP(LSL_16) | (s) << 4 | (d),
+#define _lsl_32(s,d)          _MKOP(LSL_32) | (s) << 4 | (d),
+#define _lsl_64(s,d)          _MKOP(LSL_64) | (s) << 4 | (d),
+#define _lsr_8(s,d)           _MKOP(LSR_8)  | (s) << 4 | (d),
+#define _lsr_16(s,d)          _MKOP(LSR_16) | (s) << 4 | (d),
+#define _lsr_32(s,d)          _MKOP(LSR_32) | (s) << 4 | (d),
+#define _lsr_64(s,d)          _MKOP(LSR_64) | (s) << 4 | (d),
+#define _rol_8(s,d)           _MKOP(ROL_8)  | (s) << 4 | (d),
+#define _rol_16(s,d)          _MKOP(ROL_16) | (s) << 4 | (d),
+#define _rol_32(s,d)          _MKOP(ROL_32) | (s) << 4 | (d),
+#define _rol_64(s,d)          _MKOP(ROL_64) | (s) << 4 | (d),
+#define _ror_8(s,d)           _MKOP(ROR_8)  | (s) << 4 | (d),
+#define _ror_16(s,d)          _MKOP(ROR_16) | (s) << 4 | (d),
+#define _ror_32(s,d)          _MKOP(ROR_32) | (s) << 4 | (d),
+#define _ror_64(s,d)          _MKOP(ROR_64) | (s) << 4 | (d),
 
-////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 //  misc group
 //
-////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-#define _madd_f32(s,d,m,c)    _MKOP(MUL_ADD_F32)|(s)<<4|(d),(m)<<8|(c),
-#define _madd_f64(s,d,m,c)    _MKOP(MUL_ADD_F64)|(s)<<4|(d),(s)<<8|(c),
+#define _madd_f32(s,d,m,c)    _MKOP(MUL_ADD_F32) | (s) << 4 | (d),(m) << 8 | (c),
+#define _madd_f64(s,d,m,c)    _MKOP(MUL_ADD_F64) | (s) << 4 | (d),(s) << 8 | (c),
 
 #endif
 

--- a/source/include/vm_linker.hpp
+++ b/source/include/vm_linker.hpp
@@ -181,7 +181,8 @@ namespace ExVM {
       // Run the linking Process
       int link();
 
-
+      // Return an executable ready for passing to the Interpreter class. Once we have this, we can delete
+      // the Linker instance, unless we want to keep it for debugging etc.
       Executable* getExecutable();
 
       Linker(uint32 defSegmentCount = DEF_INI_TABLE_SIZE, uint32 defSegmentDelta = DEF_INC_TABLE_DELTA);

--- a/source/include/vm_linker.hpp
+++ b/source/include/vm_linker.hpp
@@ -142,7 +142,7 @@ namespace ExVM {
       // Increment size for RawSegmentData array
       uint32 delta;
 
-      int defineSymbol(SymbolMap*& map, const char* name, void* address);
+      int defineSymbol(SymbolMap*& map, const char* name, void* address, uint32 symbolIDSize);
 
     public:
 
@@ -164,15 +164,15 @@ namespace ExVM {
       }
 
       int defineNativeCode(const char* name, NativeCall native) {
-        return defineSymbol(nativeCodeSymbols, name, (void*)native);
+        return defineSymbol(nativeCodeSymbols, name, (void*)native, VMDefs::NATIVE_SYMBOL_ID_SIZE);
       }
 
       int defineCode(const char* name, uint16* code) {
-        return defineSymbol(codeSymbols, name, code);
+        return defineSymbol(codeSymbols, name, code, VMDefs::CODE_SYMBOL_ID_SIZE);
       }
 
       int defineData(const char* name, void* data) {
-        return defineSymbol(dataSymbols, name, data);
+        return defineSymbol(dataSymbols, name, data, VMDefs::DATA_SYMBOL_ID_SIZE);
       }
 
       // Add a RawSegmentData for linking

--- a/source/include/vm_objectfile.hpp
+++ b/source/include/vm_objectfile.hpp
@@ -1,0 +1,161 @@
+//****************************************************************************//
+//**                                                                        **//
+//** File:         vm_objectfile.hpp                                        **//
+//** Description:  Symbol definitions                                       **//
+//** Comment(s):   Internal developer version only                          **//
+//** Library:                                                               **//
+//** Created:      2017-08-14                                               **//
+//** Author(s):    Karl Churchill                                           **//
+//** Note(s):                                                               **//
+//** Copyright:    (C)1996 - , eXtropia Studios                             **//
+//**               All Rights Reserved.                                     **//
+//**                                                                        **//
+//****************************************************************************//
+
+#ifndef _VM_OBJECTFILE_HPP_
+  #define _VM_OBJECTFILE_HPP_
+  #include "vm.hpp"
+  #include "machine.hpp"
+
+namespace ExVM {
+
+
+
+  enum {
+    OF_MASK_ENDIANNESS    = 0x01,
+    OF_MASK_SECTIONS      = 0x06,
+
+    OF_FLAG_BIG_ENDIAN    = 0x00,
+    OF_FLAG_LITTLE_ENDIAN = 0x00,
+
+    OF_FLAG_CODE_SECTION  = 0x02, // File contains code section
+    OF_FLAG_DATA_SECTION  = 0x04, // File contains data section
+  };
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// Main ExVN Object File header
+//
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+  struct BaseFileHeader {
+
+    // The first 8 bytes of the file are interpreted the same way regardless of machine word size or endianness.
+
+    //  0 : Magic
+    char  fileId[4];
+
+    //  4 : Indicates the minimum VM Capability Level
+    uint8 reqiredCapabilityLevel;
+
+    //  5 : File flags, indicate the endianness of the data in the file.
+    uint8 flags;
+
+    //  6 : reserved
+    uint8 reserved[2];
+
+    // From now on, we have data that must be potentially byteswapped on loadoing.
+
+    //  8 : Version of the code in the object file
+    uint16 version;
+
+    // 10 : Revision of the code in the object file
+    uint16 revision;
+
+    // 12 : Total size of the object data, in bytes.
+    uint32 totalSize;
+
+    // 16 : Number of export symbols. Each record corresponds to a SymbolRef containing 2 32-bit values. An empty export
+    //      table is impossible because a file that exports nothing can have no action taken on it
+    uint32 exportSymbolTableLength;
+  };
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// Code Header, only present when mainHeader.flags & OF_FLAG_CODE_SECTION
+//
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+  struct CodeHeader {
+
+    // Total size of the code segment, in bytes, excluding tail padding (always to 8 bytes).
+    uint32 codeSegmentSize;
+
+    // Number of literals in the code segment to swap. Each record is a single 32-bit word that represents the
+    // offset from the start of the code segment where a 32-bit literal exists.
+    uint32 codeSwapTableLength;
+
+    // Number of import symbols
+    uint32 importSymbolTableLength;
+  };
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// Data Header, only present when mainHeader.flags & OF_FLAG_DATA_SECTION
+//
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+
+
+  struct DataHeader {
+
+    // Total size of the data segment, in bytes, excluding tail padding (always to 8 bytes).
+    uint32 dataSegmentSize;
+
+    // Total size of the name segment, in bytes, excluding tail padding (always to 8 bytes).
+    uint32 nameSegmentSize;
+    uint32 complexTypesSegmentSize;
+
+    // Number of literals in the code segment to swap. Each record is a single 32-bit word that represents the
+    // offset from the start of the code segment where a 32-bit literal exists.
+    uint32 codeSwapTableLength;
+
+    // Number of blocks of 16-bit words in the data segment to swap. Each record is a pair of 32-bit values, one for
+    // the offset from the start of the data segment where a 16-bit block exists and one for the count of the 16-bit
+    // words in the block.
+    uint32 data16BitSwapTableLength;
+
+    // Number of blocks of 32-bit words in the data segment to swap. Each record is a pair of 32-bit values, one for
+    // the offset from the start of the data segment where a 32-bit block exists and one for the count of the 32-bit
+    // words in the block.
+    uint32 data32BitSwapTableLength;
+
+    // Number of blocks of 64-bit words in the data segment to swap. Each record is a pair of 32-bit values, one for
+    // the offset from the start of the data segment where a 64-bit block exists and one for the count of the 64-bit
+    // words in the block.
+    uint32 data64BitSwapTableLength;
+
+    // Number of blocks of complex types in the data segment to swap. Each record is a triplet of 32-bit values, one for
+    // the offset from the start of the data segment where a complex type block exists, one for the count of the elements
+    // in the block and one for the complex type lookup that gives the member count and offset in to the complex types
+    // segment data.
+    uint32 dataComplexTypeSwapTableLength;
+
+    // Number of complex types in the complex types table. Each record is a pair of 32-bit values, one for the offset
+    // from the start of the complex types segment for the structure definition and one for the member count.
+    uint32 complexTypesTableLength;
+  };
+
+  struct SimpleDataSwapTableEntry {
+    uint32 offset;
+    uint32 length;
+  };
+
+  struct ComplexDataSwapTableEntry {
+    uint32 offset;
+    uint32 length;
+    uint32 typeLookup;
+  };
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// Standard Header, when both code and data are present, code is first, data second.
+//
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+  struct StandardHeader {
+    CodeHeader codeHeader;
+    DataHeader dataHeader;
+  };
+
+#endif

--- a/source/include/vm_objectfile.hpp
+++ b/source/include/vm_objectfile.hpp
@@ -95,8 +95,6 @@ namespace ExVM {
 //
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-
-
   struct DataHeader {
 
     // Total size of the data segment, in bytes, excluding tail padding (always to 8 bytes).
@@ -136,15 +134,24 @@ namespace ExVM {
     uint32 complexTypesTableLength;
   };
 
-  struct SimpleDataSwapTableEntry {
+  // Simple datatype used wherever there is a 32-bit offset/count pair such as the various swap tables
+  struct OffsetCountPair {
     uint32 offset;
-    uint32 length;
+    uint32 count;
   };
 
-  struct ComplexDataSwapTableEntry {
-    uint32 offset;
-    uint32 length;
-    uint32 typeLookup;
+  // Simple structure that defines a record in the dataComplexTypeSwapTable
+  struct ComplexDataSwapTableEntry : public OffsetCountPair {
+    // Additional field for the type lookup
+    uint32 type;
+  };
+
+  // Enumerations of Complex Type members
+  enum {
+    CT_ELEMENT_8   = 0,
+    CT_ELEMENT_16  = 1,
+    CT_ELEMENT_32  = 2,
+    CT_ELEMENT_64  = 3,
   };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/source/include/vm_opcodes.hpp
+++ b/source/include/vm_opcodes.hpp
@@ -91,20 +91,16 @@ typedef enum {
 
   // load global reference
   // ld.x label,rX
-  // [opcode] [ 0 : rX]
-  // [ extension data ]
-  // [ extension data ]
-
-  // in object code format
-  // [ MSB : 1-bit internal/external, 15-bit index MSW ]
-  // [ 16-bit index LSW ]
-
-  // in memory
-  // [ 32-bit endian native operand address in host memory ]
+  // [opcode] [ Data Symbol ID {16:19} : rX ]
+  // [          Data Symbol ID {0:15}       ]
 
   _LD_8, _LD_16, _LD_32, _LD_64,
 
-  // loads the address of the operand into a register
+  // loads the address implied by the symbol ID into the specified address reguster:
+  // lda label, rX
+  // [opcode] [ Data Symbol ID {16:19} : rX ]
+  // [          Data Symbol ID {0:15}       ]
+
   _LD_ADDR,
 
   // store group ////////////////////////////////////////
@@ -138,16 +134,8 @@ typedef enum {
 
   // store global reference
   // st.x rX,label
-  // [opcode] [ 0 : rX]
-  // [ extension data ]
-  // [ extension data ]
-
-  // in object code format
-  // [ MSB : 1-bit internal/external, 15-bit index MSW ]
-  // [ 16-bit index LSW ]
-
-  // in memory
-  // [ 32-bit endian native operand address in host memory ]
+  // [opcode] [ Data Symbol ID {16:19} : rX ]
+  // [          Data Symbol ID {0:15}       ]
 
   _ST_8, _ST_16, _ST_32, _ST_64,
 
@@ -183,16 +171,8 @@ typedef enum {
 
   // call global reference
   // call label
-  // [opcode] [     0 ]
-  // [ extension data ]
-  // [ extension data ]
-
-  // in object code format
-  // [ MSB : 1-bit internal/external, 15-bit index MSW ]
-  // [ 16-bit index LSW ]
-
-  // in memory
-  // [ 32-bit endian native operand address in host memory ]
+  // [opcode] [ Code Symbol ID{16:24} ]
+  // [          Code Symbol ID{0-15}  ]
 
   _CALL, _CALLN, _RET,
 

--- a/source/include/vm_symbol.hpp
+++ b/source/include/vm_symbol.hpp
@@ -175,8 +175,6 @@ namespace ExVM {
 
     public:
       enum {
-        // The default maximum number of symbols to allow. This is basically limited by the size of symbols in VM
-        DEF_MAX_SYMBOLS        = 1 << (VMDefs::SYMBOL_ID_SIZE * 8),
         DEF_INI_TABLE_SIZE     = 128,
         DEF_INC_TABLE_DELTA    = 128
       };
@@ -215,7 +213,7 @@ namespace ExVM {
         return &symbols[symbolID];
       }
 
-      SymbolMap(uint32 maxSize = DEF_MAX_SYMBOLS, uint32 iniSize = DEF_INI_TABLE_SIZE, uint32 delta = DEF_INC_TABLE_DELTA);
+      SymbolMap(uint32 maxSize, uint32 iniSize = DEF_INI_TABLE_SIZE, uint32 delta = DEF_INC_TABLE_DELTA);
       ~SymbolMap();
   };
 

--- a/source/include/vm_targetmacros.hpp
+++ b/source/include/vm_targetmacros.hpp
@@ -41,17 +41,18 @@
     #define  _EX_U8_2 ((vm->pc.extU8)[0])
   #endif
 
-  #define _SI(x)  (((x)&0x00F0)>>4)       // small immediate
-  #define _RS(x)  (((x)&0x00F0)>>4)       // source register in 2 operand
-  #define _RD(x)  ((x)&0x000F)            // dest register in 2 operand
-  #define _RX(x)  ((x)&0x000F)            // source/dest register in 1 operand
-  #define _SC(x)  ((x)>>8)                // scale
-  #define _RI(x)  ((x)&0xF)               // index register
-  #define _B8(x)  ((sint8)((x)&0xFF))     // 8-bit branch (is operand byte)
+  #define _SI(x)  (((x) & 0x00F0) >> 4)       // small immediate
+  #define _RS(x)  (((x) & 0x00F0) >> 4)       // source register in 2 operand
+  #define _RD(x)  ((x) & 0x000F)            // dest register in 2 operand
+  #define _RX(x)  ((x) & 0x000F)            // source/dest register in 1 operand
+  #define _SC(x)  ((x) >> 8)                // scale
+  #define _RI(x)  ((x) & 0xF)               // index register
+  #define _B8(x)  ((sint8)((x) & 0xFF))     // 8-bit branch (is operand byte)
   #define _EX_U16 (*vm->pc.extU16++)
   #define _EX_U32 (*vm->pc.extU32++)
   #define _EX_S16 (*vm->pc.extS16++)
   #define _EX_S32 (*vm->pc.extS32++)
+  #define _SU(x)  ((uint32)((x) & 0x00F0) << 12)
 
   #if X_PTRSIZE == XA_PTRSIZE64
     #define PTR_CH   _pch
@@ -83,7 +84,7 @@
 
   #ifdef VM_DEBUG
     #define _DECLARE_DATA_SYMBOL(x)             \
-    uint16 x = _EX_U16;                         \
+    uint32 x = _EX_U16 | _SU(op);               \
     if (x >= vm->dataSymbolCount) {             \
       vm->status = VMDefs::UNKNOWN_DATA_SYMBOL; \
       debuglog(LOG_ERROR, "Runtime error: Unknown data symbol : %d\n", (int)x); \
@@ -92,7 +93,7 @@
     }
   #else
     #define _DECLARE_DATA_SYMBOL(x)             \
-    uint16 x = _EX_U16;                         \
+    uint32 x = _EX_U16 | _SU(op);               \
     if (x >= vm->dataSymbolCount) {             \
       vm->status = VMDefs::UNKNOWN_DATA_SYMBOL; \
       _HALT                                     \

--- a/source/op_jump.cpp
+++ b/source/op_jump.cpp
@@ -69,7 +69,7 @@ void ExVM::Interpreter::doBCALL16(ExVM::Interpreter* vm, uint16 op) {
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 void ExVM::Interpreter::doCALL(ExVM::Interpreter* vm, uint16 op) {
-  uint16 symbol = _EX_U16;
+  uint32 symbol = (uint32)_EX_U16 | ((uint32)op & 0xFF) << 16;
   if (symbol >= vm->codeSymbolCount) {
     vm->status = VMDefs::UNKNOWN_CODE_SYMBOL;
 
@@ -97,7 +97,7 @@ void ExVM::Interpreter::doCALL(ExVM::Interpreter* vm, uint16 op) {
 
 void ExVM::Interpreter::doCALLN(ExVM::Interpreter* vm, uint16 op) {
 
-  uint16 symbol = _EX_U16;
+  uint32 symbol = (uint32)_EX_U16 | ((uint32)op & 0xFF) << 16;
   if (symbol >= vm->nativeCodeSymbolCount) {
     vm->status = VMDefs::UNKNOWN_NATIVE_CODE_SYMBOL;
 

--- a/source/test_symbol.cpp
+++ b/source/test_symbol.cpp
@@ -81,7 +81,7 @@ const char* leaving  = "Bye World!!!\n";
 void testSymbolMap() {
   std::puts("Performing SymbolMap tests...");
 
-  SymbolMap symbolMap;
+  SymbolMap symbolMap(10);
   symbolMap.define("greeting", (char*)greeting);
   symbolMap.define("leaving",  (char*)leaving);
   symbolMap.define("greeting", (char*)leaving);

--- a/source/vmprogram.cpp
+++ b/source/vmprogram.cpp
@@ -341,7 +341,10 @@ void runTestExample() {
   // Grab the executable layout
   Executable* executable = linker->getExecutable();
 
-  // Dump it
+  // Dispose of the linker
+  delete linker;
+
+  // Dump the Executable
   if (executable) {
     printf(
       "Linked Executable at %p {\n"
@@ -400,6 +403,5 @@ void runTestExample() {
     std::puts("\nDid not link an Executable.\n");
   }
 
-  delete linker;
 }
 


### PR DESCRIPTION
Expansion of Symbol ID ranges:
- Data Symbol ID values are now up to 20 bits, allowing for up to 1048575 globally defined symbols (0x000FFFFF is reserved as the undefined reference).
- All instruction handlers that deal with data symbols have been modified to reconstruct the full 20 bit range for lookup.
- Code and Native Code Symbol ID values are now up to 24 bits, allowing for up to 16777215 globally defined symbols (0x00FFFFFF is reserved as the undefined reference).
- All instruction handlers that call have been modified to reconstruct the full 24 bit range for lookup.

Current implementation intentionally restricts data, code and native Symbol ID values to 20 bits each. The offset values into the data section are unchanged for the purposes of resolved symbol ID injection; rather the offset value is considered to be right-justified.
