### PR TITLE
Internal/tidying - Warnings

### DIFF
--- a/source/include/machine.hpp
+++ b/source/include/machine.hpp
@@ -66,6 +66,14 @@ any pointer %p
     typedef unsigned long int uint64;
     typedef float float32;
     typedef double float64;
+
+    // Formatting Templates
+    #define FS16 "hd"
+    #define FU16 "hu"
+    #define FS32 "d"
+    #define FU32 "u"
+    #define FS64 "ld"
+    #define FU64 "lu"
   #else
     #define X_PTRSIZE XA_PTRSIZE32
     typedef signed char sint8;
@@ -78,6 +86,14 @@ any pointer %p
     typedef unsigned long long int uint64;
     typedef float float32;
     typedef double float64;
+
+    // Formatting Templates
+    #define FS16 "hd"
+    #define FU16 "hu"
+    #define FS32 "ld"
+    #define FU32 "lu"
+    #define FS64 "lld"
+    #define FU64 "llu"
   #endif
 
   // Target sanity checks

--- a/source/include/opcodes/vector/op_vec_smin_impl.hpp
+++ b/source/include/opcodes/vector/op_vec_smin_impl.hpp
@@ -93,7 +93,7 @@ _DEFINE_OP(VSMIN_S8) {
   // Super naive reference implementation
   sint8* src = vm->gpr[(vArgs & 0x00F0) >> 4].pS8();
   uint32 i   = vm->gpr[(vArgs & 0x000F)].u32();
-  sint8  min = -128;
+  sint8  min = 0x80;
   sint8  val = *src;
 
   // Bail if we find min
@@ -113,7 +113,7 @@ _DEFINE_OP(VSMIN_S16) {
   // Super naive reference implementation
   sint16* src = vm->gpr[(vArgs & 0x00F0) >> 4].pS16();
   uint32  i   = vm->gpr[(vArgs & 0x000F)].u32();
-  sint16  min = -32768;
+  sint16  min = 0x8000;
   sint16  val = *src;
 
   // Bail if we find min
@@ -133,7 +133,7 @@ _DEFINE_OP(VSMIN_S32) {
   // Super naive reference implementation
   sint32* src = vm->gpr[(vArgs & 0x00F0) >> 4].pS32();
   uint32  i   = vm->gpr[(vArgs & 0x000F)].u32();
-  sint32  min = -2147483648L;
+  sint32  min = 0x80000000;
   sint32  val = *src;
 
   // Bail if we find min
@@ -153,7 +153,7 @@ _DEFINE_OP(VSMIN_S64) {
   // Super naive reference implementation
   sint64* src = vm->gpr[(vArgs & 0x00F0) >> 4].pS64();
   uint32  i   = vm->gpr[(vArgs & 0x000F)].u32();
-  sint64  min = -9223372036854775807LL;
+  sint64  min = 0x8000000000000000;
   sint64  val = *src;
 
   // Bail if we find min

--- a/source/include/platforms/machine_linux_generic_impl.hpp
+++ b/source/include/platforms/machine_linux_generic_impl.hpp
@@ -19,7 +19,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
-struct timezone MilliClock::tz = { 0 };
+struct timezone MilliClock::tz = { 0, 0 };
 
 uint32 MilliClock::elapsed() {
   timeval current;

--- a/source/include/vm_core.hpp
+++ b/source/include/vm_core.hpp
@@ -31,8 +31,11 @@ namespace ExVM {
 //
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-
+  class FunctionalTest;
   class Interpreter {
+
+    friend ExVM::FunctionalTest;
+
     public:
       enum {
         NUM_GPR         = 16,   // Number of general purpose registers
@@ -46,19 +49,17 @@ namespace ExVM {
       #include "vm_gpr.hpp"
 
     private:
-      GPR       gpr[Interpreter::NUM_GPR];    // register set
+      GPR gpr[Interpreter::NUM_GPR];    // register set
 
       union {
-        const uint16*             inst;   // normal interpretation
-        const uint8*              extU8;
-        const uint16*             extU16;
-        const uint32*             extU32;
-        const sint8*              extS8;
-        const sint16*             extS16;
-        const sint32*             extS32;
-        const float32*            extF32;
-        const uint16* const *     extCodeAddr;
-        const NativeCall* const * extNativeCodeAddr;
+        const uint16*  inst;   // normal interpretation
+        const uint8*   extU8;
+        const uint16*  extU16;
+        const uint32*  extU32;
+        const sint8*   extS8;
+        const sint16*  extS16;
+        const sint32*  extS32;
+        const float32* extF32;
       } pc;         // program counter
 
       uint16**  callStack;  // return address stack
@@ -81,18 +82,18 @@ namespace ExVM {
       NativeCall* nativeCodeSymbol;
       uint16**    codeSymbol;
       void**      dataSymbol;
-      uint32    status;
+      uint32      status;
 
-      size_t    regStackSize;
-      size_t    dataStackSize;
-      size_t    callStackSize;
+      size_t  regStackSize;
+      size_t  dataStackSize;
+      size_t  callStackSize;
 
-      float64   totalTime;
-      float64   nativeTime;
+      float64 totalTime;
+      float64 nativeTime;
 
-      uint16    nativeCodeSymbolCount;
-      uint16    codeSymbolCount;
-      uint16    dataSymbolCount;
+      uint32  nativeCodeSymbolCount;
+      uint32  codeSymbolCount;
+      uint32  dataSymbolCount;
 
       #if _VM_INTERPRETER == _VM_INTERPRETER_FUNC_TABLE
         #include "vm_handlers.hpp"
@@ -108,24 +109,19 @@ namespace ExVM {
         return status;
       }
 
-    public:
-
-      void setNativeCodeSymbolTable(NativeCall* symbol, uint16 count);
-      void setCodeSymbolTable(uint16** symbol, uint16 count);
-      void setDataSymbolTable(void** symbol, uint16 count);
-
-      void setExecutable(Executable* executable);
-
-      GPR& getReg(sint32 i) {
+      GPR&    getReg(sint32 i) {
         return gpr[(i & 0xF)];
       }
 
+      void setNativeCodeSymbolTable(NativeCall* symbol, uint32 count);
+      void setCodeSymbolTable(uint16** symbol, uint32 count);
+      void setDataSymbolTable(void** symbol, uint32 count);
+      void setExecutable(Executable* executable);
       void setPC(uint16* newPC) {
         pc.inst = newPC;
       }
 
       void dump();
-
       void execute();
 
     private:
@@ -144,9 +140,7 @@ namespace ExVM {
       static void doPOP_16(Interpreter* vm, uint16 op);
       static void doPOP_32(Interpreter* vm, uint16 op);
       static void doPOP_64(Interpreter* vm, uint16 op);
-
       static void doVEC1(Interpreter* vm, uint16 op);
-
       static void doADV(Interpreter* vm, uint16 op);
   };
 
@@ -163,12 +157,12 @@ namespace ExVM {
     NativeCall* nativeCodeAddresses;
     uint16**    codeAddresses;
     void**      dataAddresses;
-    uint16      nativeCodeCount;
-    uint16      codeCount;
-    uint16      dataCount;
-    uint16      main;
+    uint32      nativeCodeCount;
+    uint32      codeCount;
+    uint32      dataCount;
+    uint32      main;
 
-    static Executable* allocate(uint16 nativeCount, uint16 codeCount, uint16 dataCount);
+    static Executable* allocate(uint32 nativeCount, uint32 codeCount, uint32 dataCount);
     static void release(Executable* executable);
   };
 

--- a/source/include/vm_interpreter_func_table.hpp
+++ b/source/include/vm_interpreter_func_table.hpp
@@ -15,7 +15,7 @@
 #ifndef _VM_INTERPRETER_FUNC_TABLE_HPP_
   #define _VM_INTERPRETER_FUNC_TABLE_HPP_
   #define _DECLARE_OP(x)  static void do##x(ExVM::Interpreter*, uint16);
-  #define _DEFINE_OP(x)   void ExVM::Interpreter::do##x(ExVM::Interpreter* vm, uint16 op UNUSED)
+  #define _DEFINE_OP(x)   void ExVM::Interpreter::do##x(ExVM::Interpreter* vm UNUSED, uint16 op UNUSED)
   #define _REFER_OP(x)    ExVM::Interpreter::do##x
   #define _END_OP
   #define _HALT return;

--- a/source/op_advanced.cpp
+++ b/source/op_advanced.cpp
@@ -68,7 +68,7 @@ void ExVM::Interpreter::doADV(ExVM::Interpreter* vm, uint16 op) {
 #if _VM_INTERPRETER == _VM_INTERPRETER_FUNC_TABLE
 
   #undef _DEFINE_OP
-  #define _DEFINE_OP(x) void ExVM::Interpreter::do##x(ExVM::Interpreter* vm, uint16 vArgs UNUSED)
+  #define _DEFINE_OP(x) void ExVM::Interpreter::do##x(ExVM::Interpreter* vm UNUSED, uint16 vArgs UNUSED)
 
   #include "include/opcodes/advanced/op_adv_const_impl.hpp"
   #include "include/opcodes/advanced/op_adv_roots_impl.hpp"

--- a/source/op_vector.cpp
+++ b/source/op_vector.cpp
@@ -16,6 +16,8 @@
 #include "include/machine.hpp"
 #include <cstdio>
 
+#include <limits.h>
+
 #if _VM_INTERPRETER == _VM_INTERPRETER_FUNC_TABLE
   #include "include/vm_interpreter_func_table.hpp"
 #elif _VM_INTERPRETER == _VM_INTERPRETER_SWITCH_CASE
@@ -65,7 +67,7 @@ void ExVM::Interpreter::doVEC1(ExVM::Interpreter* vm, uint16 op) {
 #if _VM_INTERPRETER == _VM_INTERPRETER_FUNC_TABLE
   #include <cmath>
   #undef _DEFINE_OP
-  #define _DEFINE_OP(x) void ExVM::Interpreter::do##x(ExVM::Interpreter* vm, uint16 vArgs UNUSED)
+  #define _DEFINE_OP(x) void ExVM::Interpreter::do##x(ExVM::Interpreter* vm UNUSED, uint16 vArgs UNUSED)
 
   #include "include/opcodes/vector/op_vec_fill_impl.hpp"
   #include "include/opcodes/vector/op_vec_smin_impl.hpp"
@@ -107,7 +109,7 @@ void ExVM::Interpreter::doVEC1(ExVM::Interpreter* vm, uint16 op) {
   #include "include/opcodes/vector/op_vec_vbitwise_impl.hpp"
 
   #include "include/opcodes/vector/op_vec_vmap_impl.hpp"
-  
+
   #include "include/opcodes/vector/op_vec_vmac_impl.hpp"
 
 #endif

--- a/source/test_linker.cpp
+++ b/source/test_linker.cpp
@@ -122,18 +122,18 @@ int main() {
     "\texportTable       : %p\n"
     "\timportTable       : %p\n"
     "\tmagic             : 0x%08X\n"
-    "\texportTableLength : %u\n"
-    "\timportTableLength : %u\n"
-    "\tcodeSegmentLength : %u\n"
-    "\tdataSegmentLength : %u\n"
-    "\tnameSegmentLength : %u\n"
+    "\texportTableLength : %" FU32 "\n"
+    "\timportTableLength : %" FU32 "\n"
+    "\tcodeSegmentLength : %" FU32 "\n"
+    "\tdataSegmentLength : %" FU32 "\n"
+    "\tnameSegmentLength : %" FU32 "\n"
     "}\n",
     mockLoadSegment.codeSegment,
     mockLoadSegment.dataSegment,
     mockLoadSegment.nameSegment,
     mockLoadSegment.exportTable,
     mockLoadSegment.importTable,
-    mockLoadSegment.magic,
+    (unsigned)mockLoadSegment.magic,
     mockLoadSegment.exportTableLength,
     mockLoadSegment.importTableLength,
     mockLoadSegment.codeSegmentLength,
@@ -143,7 +143,7 @@ int main() {
 
   std::puts("Code Segment before linking...");
   for (uint32 i = 0; i < mockLoadSegment.codeSegmentLength; i++) {
-    std::printf("%u : 0x%04X\n", i, mockLoadSegment.codeSegment[i]);
+    std::printf("%" FU32 " : 0x%04X\n", i, mockLoadSegment.codeSegment[i]);
   }
 
   Linker testLinker;
@@ -153,7 +153,7 @@ int main() {
 
   std::puts("Code Segment after linking...");
   for (uint32 i = 0; i < mockLoadSegment.codeSegmentLength; i++) {
-    std::printf("%u : 0x%04X\n", i, mockLoadSegment.codeSegment[i]);
+    std::printf("%" FU32 " : 0x%04X\n", i, mockLoadSegment.codeSegment[i]);
   }
 
   // Now get the linked executable
@@ -165,9 +165,9 @@ int main() {
     "\tnativeCodeAddresses : %p\n"
     "\tcodeAddresses       : %p\n"
     "\tdataAddresses       : %p\n"
-    "\tnativeCodeCount     : %u\n"
-    "\tcodeCount           : %u\n"
-    "\tdataCount           : %u\n"
+    "\tnativeCodeCount     : %" FU32 "\n"
+    "\tcodeCount           : %" FU32 "\n"
+    "\tdataCount           : %" FU32 "\n"
     "}\n",
     executable->nativeCodeAddresses,
     executable->codeAddresses,
@@ -178,15 +178,15 @@ int main() {
   );
 
   for (uint32 i = 0; i < executable->nativeCodeCount; i++) {
-    std::printf("NativeCall Symbol ID : %u -> %p\n", i, executable->nativeCodeAddresses[i]);
+    std::printf("NativeCall Symbol ID : %" FU32 " -> %p\n", i, executable->nativeCodeAddresses[i]);
   }
 
   for (uint32 i = 0; i < executable->codeCount; i++) {
-    std::printf("Code       Symbol ID : %u -> %p\n", i, executable->codeAddresses[i]);
+    std::printf("Code       Symbol ID : %" FU32 " -> %p\n", i, executable->codeAddresses[i]);
   }
 
   for (uint32 i = 0; i < executable->dataCount; i++) {
-    std::printf("Data       Symbol ID : %u -> %p\n", i, executable->dataAddresses[i]);
+    std::printf("Data       Symbol ID : %" FU32 " -> %p\n", i, executable->dataAddresses[i]);
   }
 
   Executable::release(executable);

--- a/source/test_symbol.cpp
+++ b/source/test_symbol.cpp
@@ -89,7 +89,7 @@ void testSymbolMap() {
   const Symbol* list = symbolMap.getList();
 
   for (uint32 i = 0; i < symbolMap.size(); i++) {
-    std::printf("\t%u : %s @ %p\n", i, list[i].name, list[i].address.raw);
+    std::printf("\t%" FU32 " : %s @ %p\n", i, list[i].name, list[i].address.raw);
   }
 
 }

--- a/source/vm_core.cpp
+++ b/source/vm_core.cpp
@@ -129,17 +129,17 @@ void Interpreter::dump() {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-void Interpreter::setNativeCodeSymbolTable(NativeCall* symbol, uint16 count) {
+void Interpreter::setNativeCodeSymbolTable(NativeCall* symbol, uint32 count) {
   nativeCodeSymbol      = symbol;
   nativeCodeSymbolCount = count;
 }
 
-void Interpreter::setCodeSymbolTable(uint16** symbol, uint16 count) {
+void Interpreter::setCodeSymbolTable(uint16** symbol, uint32 count) {
   codeSymbol      = symbol;
   codeSymbolCount = count;
 }
 
-void Interpreter::setDataSymbolTable(void** symbol, uint16 count) {
+void Interpreter::setDataSymbolTable(void** symbol, uint32 count) {
   dataSymbol      = symbol;
   dataSymbolCount = count;
 }

--- a/source/vm_core.cpp
+++ b/source/vm_core.cpp
@@ -104,7 +104,7 @@ void Interpreter::dump() {
   for (int i = 0; i < NUM_GPR; i++) {
     printf("%2d: 0x%08X%08X : %12d : %6d : %4d : %c : %.8f\n", i,
       (unsigned)gpr[i].getMSW(), (unsigned)gpr[i].getLSW(),
-      gpr[i].s32(),
+      (int)gpr[i].s32(),
       (int)gpr[i].s16(),
       (int)gpr[i].s8(),
       (int)((gpr[i].u8()>32 && gpr[i].u8() < 127) ? gpr[i].u8() : '.'),

--- a/source/vm_linker.cpp
+++ b/source/vm_linker.cpp
@@ -365,7 +365,7 @@ Executable* Linker::getExecutable() {
 //
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-Executable* Executable::allocate(uint16 nativeCount, uint16 codeCount, uint16 dataCount) {
+Executable* Executable::allocate(uint32 nativeCount, uint32 codeCount, uint32 dataCount) {
   size_t baseAllocSize   = sizeof(Executable);
   size_t nativeTableSize = nativeCount * sizeof(NativeCall);
   size_t codeTableSize   = codeCount   * sizeof(uint16*);

--- a/source/vm_linker.cpp
+++ b/source/vm_linker.cpp
@@ -96,7 +96,7 @@ int Linker::addRawSegment(RawSegmentData* rawSegment) {
     !rawSegments &&
     !(rawSegments = (RawSegmentData**)std::calloc(currSize, sizeof(RawSegmentData*)))
   ) {
-    debuglog(LOG_ERROR, "Unable to allocate initial RawSegmentData pointer table for %u entries", currSize);
+    debuglog(LOG_ERROR, "Unable to allocate initial RawSegmentData pointer table for %" FU32 " entries", currSize);
     return Error::OUT_OF_MEMORY;
   }
 
@@ -109,17 +109,17 @@ int Linker::addRawSegment(RawSegmentData* rawSegment) {
     uint32 newSize = currSize + delta;
     RawSegmentData** growSegments = (RawSegmentData**)std::realloc(rawSegments, newSize * sizeof(RawSegmentData*));
     if (!growSegments) {
-      debuglog(LOG_ERROR, "Unable to grow RawSegmentData pointer table to %u entries", newSize);
+      debuglog(LOG_ERROR, "Unable to grow RawSegmentData pointer table to %" FU32 " entries", newSize);
       return Error::OUT_OF_MEMORY;
     }
 
     rawSegments = growSegments;
     currSize    = newSize;
-    debuglog(LOG_INFO, "Expanded Symbol table to %u entries", currSize);
+    debuglog(LOG_INFO, "Expanded Symbol table to %" FU32 " entries", currSize);
   }
 
   rawSegments[entry] = rawSegment;
-  debuglog(LOG_INFO, "Added RawSegmentData instance at %p as entry %u", rawSegment, entry);
+  debuglog(LOG_INFO, "Added RawSegmentData instance at %p as entry %" FU32, rawSegment, entry);
 
   return Error::SUCCESS;
 }
@@ -151,7 +151,7 @@ int Linker::enumerateAllSymbols() {
   for (uint32 i = 0; i < numRawSegments; i++) {
     RawSegmentData* segment = rawSegments[i];
 
-    debuglog(LOG_INFO, "Processing RawSegmentData[%u] %p Export Symbols", i, segment);
+    debuglog(LOG_INFO, "Processing RawSegmentData[%" FU32 "] %p Export Symbols", i, segment);
     for (uint32 j = 0; j < segment->exportTableLength; j++) {
       RawSegmentData::SymbolRef* symbolRef  = &segment->exportTable[j];
       const char*                symbolName = symbolRef->getSymbolName(segment->nameSegment);
@@ -208,7 +208,7 @@ int Linker::resolveToEnumerated() {
   for (uint32 i = 0; i < numRawSegments; i++) {
     RawSegmentData* segment = rawSegments[i];
 
-    debuglog(LOG_INFO, "Processing RawSegmentData[%u] %p Import Symbols", i, segment);
+    debuglog(LOG_INFO, "Processing RawSegmentData[%" FU32 "] %p Import Symbols", i, segment);
     for (uint32 j = 0; j < segment->importTableLength; j++) {
       RawSegmentData::SymbolRef* symbolRef  = &segment->importTable[j];
       const char*                symbolName = symbolRef->getSymbolName(segment->nameSegment);
@@ -304,7 +304,7 @@ int Linker::resolveToEnumerated() {
           break;
       }
 
-      debuglog(LOG_INFO, "Injecting symbol '%s' ID %d into code segment at offset %u [%p]", symbolName, symbolID, symbolRef->offset, injectAddr);
+      debuglog(LOG_INFO, "Injecting symbol '%s' ID %d into code segment at offset %" FU32 " [%p]", symbolName, symbolID, symbolRef->offset, injectAddr);
       *injectAddr++ = opcodeWord;
       *injectAddr   = (uint16)(symbolID & 0xFFFF);
     }
@@ -329,14 +329,14 @@ Executable* Linker::getExecutable() {
 
   if (nativeCodeSymbols) {
     const Symbol* native = nativeCodeSymbols->getList();
-    for (int i = 0; i < executable->nativeCodeCount; i++) {
+    for (uint32 i = 0; i < executable->nativeCodeCount; i++) {
       executable->nativeCodeAddresses[i] = native[i].address.native;
     }
   }
 
   if (codeSymbols) {
     const Symbol* code = codeSymbols->getList();
-    for (int i = 0; i < executable->codeCount; i++) {
+    for (uint32 i = 0; i < executable->codeCount; i++) {
       executable->codeAddresses[i] = code[i].address.code;
     }
 
@@ -349,7 +349,7 @@ Executable* Linker::getExecutable() {
 
   if (dataSymbols) {
     const Symbol* data = dataSymbols->getList();
-    for (int i = 0; i < executable->dataCount; i++) {
+    for (uint32 i = 0; i < executable->dataCount; i++) {
       executable->dataAddresses[i] = data[i].address.data;
     }
   }

--- a/source/vm_linker.cpp
+++ b/source/vm_linker.cpp
@@ -366,16 +366,16 @@ Executable* Linker::getExecutable() {
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 Executable* Executable::allocate(uint32 nativeCount, uint32 codeCount, uint32 dataCount) {
-  size_t baseAllocSize   = sizeof(Executable);
-  size_t nativeTableSize = nativeCount * sizeof(NativeCall);
-  size_t codeTableSize   = codeCount   * sizeof(uint16*);
-  size_t dataTableSize   = dataCount   * sizeof(void*);
+  uint32 baseAllocSize   = sizeof(Executable);
+  uint32 nativeTableSize = nativeCount * sizeof(NativeCall);
+  uint32 codeTableSize   = codeCount   * sizeof(uint16*);
+  uint32 dataTableSize   = dataCount   * sizeof(void*);
 
   // Try to allocate enought space for all of the above in a single block
-  size_t totalAllocSize  = baseAllocSize + nativeTableSize + codeTableSize + dataTableSize;
+  uint32 totalAllocSize  = baseAllocSize + nativeTableSize + codeTableSize + dataTableSize;
   uint8* baseAddress     = (uint8*)std::calloc(totalAllocSize, 1);
   if (!baseAddress) {
-    debuglog(LOG_ERROR, "Unable to allocate %u bytes for Executable structure\n", totalAllocSize);
+    debuglog(LOG_ERROR, "Unable to allocate %" FU32 " bytes for Executable structure\n", totalAllocSize);
     return 0;
   }
 

--- a/source/vm_symbol.cpp
+++ b/source/vm_symbol.cpp
@@ -75,7 +75,7 @@ SymbolNameEnumerator::SymbolNameEnumerator(uint32 maxID) :
   maxSymbolID(maxID),
   nextSymbolID(0)
 {
-  debuglog(LOG_DEBUG, "Created SymbolNameEnumerator with maxSize %u", maxSymbolID);
+  debuglog(LOG_DEBUG, "Created SymbolNameEnumerator with maxSize %" FU32, maxSymbolID);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -136,10 +136,10 @@ int SymbolNameEnumerator::checkBlock() {
   if (!nodeBlock || nodeBlock->nextFree == NODE_BLOCKSIZE) {
     Block* newBlock = (Block*)std::calloc(1, sizeof(Block));
     if (!newBlock) {
-      debuglog(LOG_ERROR, "Unable to allocate Block of %u bytes", (uint32)sizeof(Block));
+      debuglog(LOG_ERROR, "Unable to allocate Block of %" FU32 " bytes", (uint32)sizeof(Block));
       return 0;
     }
-    debuglog(LOG_DEBUG, "Allocated Block of %u bytes at %p", (uint32)sizeof(Block), newBlock);
+    debuglog(LOG_DEBUG, "Allocated Block of %" FU32 " bytes at %p", (uint32)sizeof(Block), newBlock);
 
     // Make the newly allocated block the active one
     newBlock->prevBlock    = nodeBlock;
@@ -243,7 +243,7 @@ int SymbolNameEnumerator::enumerate(const char* name) {
 
   // Check we haven't reached the table size limit
   if (isFull()) {
-    debuglog(LOG_WARN, "Cannot add symbol %s, table limit of %u entries reached", name, maxSymbolID);
+    debuglog(LOG_WARN, "Cannot add symbol %s, table limit of %" FU32 " entries reached", name, maxSymbolID);
     return Error::TABLE_FULL;
   }
 
@@ -314,7 +314,7 @@ SymbolMap::SymbolMap(uint32 maxSize, uint32 iniSize, uint32 delta) :
 {
   debuglog(
     LOG_DEBUG,
-    "Created SymbolMap, initial size %u, max size %u, grow size %u",
+    "Created SymbolMap, initial size %" FU32 ", max size %" FU32 ", grow size %" FU32,
     currSize, maxSize, delta
   );
 }
@@ -349,7 +349,7 @@ int SymbolMap::define(const char* name, void* address) {
       !symbols &&
       !(symbols = (Symbol*)std::calloc(currSize, sizeof(Symbol)))
     ) {
-      debuglog(LOG_ERROR, "Unable to allocate initial Symbol table for %u entries", currSize);
+      debuglog(LOG_ERROR, "Unable to allocate initial Symbol table for %" FU32 " entries", currSize);
       return Error::OUT_OF_MEMORY;
     }
 
@@ -358,13 +358,13 @@ int SymbolMap::define(const char* name, void* address) {
       uint32  newSize     = currSize + delta;
       Symbol* growSymbols = (Symbol*)std::realloc(symbols, newSize * sizeof(Symbol));
       if (!growSymbols) {
-        debuglog(LOG_ERROR, "Unable to grow Symbol table to %u entries", newSize);
+        debuglog(LOG_ERROR, "Unable to grow Symbol table to %" FU32 " entries", newSize);
         return Error::OUT_OF_MEMORY;
       }
 
       symbols  = growSymbols;
       currSize = newSize;
-      debuglog(LOG_INFO, "Expanded Symbol table to %u entries", currSize);
+      debuglog(LOG_INFO, "Expanded Symbol table to %" FU32 " entries", currSize);
     }
 
     symbols[result].name = name;

--- a/source/vmprogram.cpp
+++ b/source/vmprogram.cpp
@@ -66,7 +66,7 @@ void nativeWriteBuffer(Interpreter* vm) {
   FILE *f = fopen(fileName, "wb");
   if (f) {
     fprintf(f, "P5\n%d\n%d\n255\n", w, h);
-    fwrite(vm->getReg(_r0).pCh(), 1, w*h, f);
+    fwrite(vm->getReg(_r0).pCh(), 1, w * h, f);
     fclose(f);
     printf("Wrote buffer '%s'\n", fileName);
   }
@@ -307,12 +307,12 @@ void runTestExample() {
 
   std::printf(
     "Structure Sizes\n"
-    "\tsizeof(Linker)      : %u\n"
-    "\tsizeof(Interpreter) : %u\n"
-    "\tsizeof(Executable)  : %u\n",
-    sizeof(Linker),
-    sizeof(Interpreter),
-    sizeof(Executable)
+    "\tsizeof(Linker)      : %" FU32 "\n"
+    "\tsizeof(Interpreter) : %" FU32 "\n"
+    "\tsizeof(Executable)  : %" FU32 "\n",
+    (uint32)sizeof(Linker),
+    (uint32)sizeof(Interpreter),
+    (uint32)sizeof(Executable)
   );
 
   std::puts(
@@ -351,9 +351,9 @@ void runTestExample() {
       "\tnativeCodeAddresses : %p\n"
       "\tcodeAddresses       : %p\n"
       "\tdataAddresses       : %p\n"
-      "\tnativeCodeCount     : %u\n"
-      "\tcodeCount           : %u\n"
-      "\tdataCount           : %u\n"
+      "\tnativeCodeCount     : %" FU32 "\n"
+      "\tcodeCount           : %" FU32 "\n"
+      "\tdataCount           : %" FU32 "\n"
       "}\n",
       executable,
       executable->nativeCodeAddresses,
@@ -365,15 +365,15 @@ void runTestExample() {
     );
     std::puts("NativeCall Symbol Table");
     for (uint32 i = 0; i < executable->nativeCodeCount; i++) {
-      std::printf("\tSymbol ID : %u -> %p\n", i, executable->nativeCodeAddresses[i]);
+      std::printf("\tSymbol ID : %" FU32 " -> %p\n", i, executable->nativeCodeAddresses[i]);
     }
     std::puts("Code Symbol Table");
     for (uint32 i = 0; i < executable->codeCount; i++) {
-      std::printf("\tSymbol ID : %u -> %p\n", i, executable->codeAddresses[i]);
+      std::printf("\tSymbol ID : %" FU32 " -> %p\n", i, executable->codeAddresses[i]);
     }
     std::puts("Data Symbol Table");
     for (uint32 i = 0; i < executable->dataCount; i++) {
-      std::printf("\tSymbol ID : %u -> %p\n", i, executable->dataAddresses[i]);
+      std::printf("\tSymbol ID : %" FU32 " -> %p\n", i, executable->dataAddresses[i]);
     }
 
     std::puts(


### PR DESCRIPTION
Fixed bugs left behind by symbol expansion
- uint16 were still being used as the integer type for referencing symbol ID values in several structures,
Fixed warnings caused by:
- signed/unsigned comparisons (gcc all)
- printf() template/argument mismatch (gcc all)
- integer literals at limits (gcc all)
- missing trailing initialiser in timezone structure (linux generic)
- unused function arguments (gcc all)