### PR TITLE
Cleanup

### DIFF
--- a/source/include/opcodes/advanced/enum.hpp
+++ b/source/include/opcodes/advanced/enum.hpp
@@ -19,6 +19,9 @@
 // functions that otherwise would require the use of native function calls to expose.
 
 typedef enum {
+  // Multiply Add
+  _MADD_F32,   _MADD_F64,
+
   // Load constants
   _LD_CONST_F32, _LD_CONST_F64,
 

--- a/source/include/opcodes/advanced/op_adv_madd_impl.hpp
+++ b/source/include/opcodes/advanced/op_adv_madd_impl.hpp
@@ -1,7 +1,7 @@
 //****************************************************************************//
 //**                                                                        **//
-//** File:         op_adv_lerp_impl.hpp                                     **//
-//** Description:  Interpolation                                            **//
+//** File:         op_adv_madd_impl.hpp                                     **//
+//** Description:  Multiply-Add                                             **//
 //** Comment(s):   Internal developer version only                          **//
 //** Library:                                                               **//
 //** Created:      2017-08-19                                               **//
@@ -13,19 +13,27 @@
 //****************************************************************************//
 
 
-_DEFINE_OP(LERP_F32) {
-  float32 lerp = vm->gpr[(vArgs & 0x00F0) >> 4].f32();
-  vm->gpr[(vArgs & 0x000F)].f32() =
-    (lerp * vm->gpr[(vArgs & 0xF000) >> 12].f32()) +
-    ((1.0f - lerp) * vm->gpr[(vArgs & 0x0F00) >> 8].f32());
+_DEFINE_OP(MADD_F32) {
+/*
+  vm->gpr[_RD(op)].f32() = vm->gpr[_RS(op)].f32() * vm->gpr[_EX_U8_1].f32() + vm->gpr[_EX_U8_2].f32();
+  ++vm->pc.extU16;
+*/
+  vm->gpr[(vArgs & 0x000F)].f32() = (
+    vm->gpr[(vArgs & 0x00F0) >> 4].f32() *
+    vm->gpr[(vArgs & 0x0F00) >> 8].f32()
+  ) + vm->gpr[(vArgs & 0xF000) >> 12].f32();
 }
 _END_OP
 
 
-_DEFINE_OP(LERP_F64) {
-  float64 lerp = vm->gpr[(vArgs & 0x00F0) >> 4].f64();
-  vm->gpr[(vArgs & 0x000F)].f64() =
-    (lerp * vm->gpr[(vArgs & 0xF000) >> 12].f64()) +
-    ((1.0 - lerp) * vm->gpr[(vArgs & 0x0F00) >> 8].f64());
+_DEFINE_OP(MADD_F64) {
+/*
+  vm->gpr[_RD(op)].f64() = vm->gpr[_RS(op)].f64() * vm->gpr[_EX_U8_1].f64() + vm->gpr[_EX_U8_2].f64();
+  ++vm->pc.extU16;
+*/
+  vm->gpr[(vArgs & 0x000F)].f64() = (
+    vm->gpr[(vArgs & 0x00F0) >> 4].f64() *
+    vm->gpr[(vArgs & 0x0F00) >> 8].f64()
+  ) + vm->gpr[(vArgs & 0xF000) >> 12].f64();
 }
 _END_OP

--- a/source/include/opcodes/scalar/enum.hpp
+++ b/source/include/opcodes/scalar/enum.hpp
@@ -285,12 +285,6 @@ typedef enum {
   _MAX_S8,  _MAX_S16, _MAX_S32, _MAX_S64,
   _MAX_F32, _MAX_F64,
 
-  // madd.f32|f64 rS,rD,rM,rA
-  // rD = rS*rM + rA
-  // [ opcode ][rS : rD]
-  // [ 0 : rM ][ 0 : rA]
-  _MUL_ADD_F32, _MUL_ADD_F64,
-
   // Logic commands, data treat as unsigned binary
 
   // and.x rS,RD (rD &= rS)

--- a/source/include/opcodes/scalar/op_arithmetic_impl.hpp
+++ b/source/include/opcodes/scalar/op_arithmetic_impl.hpp
@@ -591,17 +591,3 @@ _DEFINE_OP(MAX_F64) {
 }
 _END_OP
 
-// MISC /////////////////////////////////////////////////////////////////////
-
-_DEFINE_OP(MUL_ADD_F32) {
-  vm->gpr[_RD(op)].f32() = vm->gpr[_RS(op)].f32() * vm->gpr[_EX_U8_1].f32() + vm->gpr[_EX_U8_2].f32();
-  ++vm->pc.extU16;
-}
-_END_OP
-
-_DEFINE_OP(MUL_ADD_F64) {
-  vm->gpr[_RD(op)].f64() = vm->gpr[_RS(op)].f64() * vm->gpr[_EX_U8_1].f64() + vm->gpr[_EX_U8_2].f64();
-  ++vm->pc.extU16;
-}
-_END_OP
-

--- a/source/include/vm_handlers.hpp
+++ b/source/include/vm_handlers.hpp
@@ -252,8 +252,6 @@ _DECLARE_OP(MAX_S32)
 _DECLARE_OP(MAX_S64)
 _DECLARE_OP(MAX_F32)
 _DECLARE_OP(MAX_F64)
-_DECLARE_OP(MUL_ADD_F32)
-_DECLARE_OP(MUL_ADD_F64)
 
 // logic group
 _DECLARE_OP(AND_8)
@@ -297,6 +295,8 @@ _DECLARE_OP(ILLEGAL);
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 // Advanced opcodes
+_DECLARE_OP(MADD_F32)
+_DECLARE_OP(MADD_F64)
 _DECLARE_OP(LD_CONST_F32)
 _DECLARE_OP(LD_CONST_F64)
 _DECLARE_OP(SQRT_F32)

--- a/source/include/vm_interpreter_adv_switch_case_impl.hpp
+++ b/source/include/vm_interpreter_adv_switch_case_impl.hpp
@@ -16,6 +16,7 @@
 
   switch (op & 0xFF) {
     // Includes added in strict order of the opcode enumerations
+    #include "opcodes/advanced/op_adv_madd_impl.hpp"
     #include "opcodes/advanced/op_adv_const_impl.hpp"
     #include "opcodes/advanced/op_adv_roots_impl.hpp"
     #include "opcodes/advanced/op_adv_trig_impl.hpp"

--- a/source/op_advanced.cpp
+++ b/source/op_advanced.cpp
@@ -86,7 +86,7 @@ void ExVM::Interpreter::doADV(ExVM::Interpreter* vm, uint16 op) {
 
   #undef _DEFINE_OP
   #define _DEFINE_OP(x) void ExVM::Interpreter::do##x(ExVM::Interpreter* vm UNUSED, uint16 vArgs UNUSED)
-
+  #include "include/opcodes/advanced/op_adv_madd_impl.hpp"
   #include "include/opcodes/advanced/op_adv_const_impl.hpp"
   #include "include/opcodes/advanced/op_adv_roots_impl.hpp"
   #include "include/opcodes/advanced/op_adv_trig_impl.hpp"

--- a/source/op_jump_table.cpp
+++ b/source/op_jump_table.cpp
@@ -257,8 +257,7 @@ const Interpreter::Handler Interpreter::handlers[256] = {
   _REFER_OP(MAX_S64),
   _REFER_OP(MAX_F32),
   _REFER_OP(MAX_F64),
-  _REFER_OP(MUL_ADD_F32),
-  _REFER_OP(MUL_ADD_F64),
+
   // logic group
   _REFER_OP(AND_8),
   _REFER_OP(AND_16),
@@ -301,6 +300,8 @@ const Interpreter::Handler Interpreter::handlers[256] = {
 };
 
 const Interpreter::Handler Interpreter::advancedHandlers[256] = {
+  _REFER_OP(MADD_F32),
+  _REFER_OP(MADD_F64),
   _REFER_OP(LD_CONST_F32),
   _REFER_OP(LD_CONST_F64),
   _REFER_OP(SQRT_F32),

--- a/source/vm_core.cpp
+++ b/source/vm_core.cpp
@@ -78,7 +78,7 @@ Interpreter::Interpreter(size_t rStackSize, size_t dStackSize, size_t cStackSize
   dataSymbolCount       = 0;
 
   debuglog(LOG_INFO, "VM compiled %d-bit native", X_PTRSIZE);
-  debuglog(LOG_INFO, "There are presently %d scalar and %d vector instructions defined", VMDefs::MAX_OP, VMDefs::MAX_VEC);
+  debuglog(LOG_INFO, "There are presently %d scalar, %d advanced and %d stream instructions defined", VMDefs::MAX_OP, VMDefs::MAX_ADV, VMDefs::MAX_VEC);
 
 }
 


### PR DESCRIPTION
Moved the multiply-add operations from the normal scalar group into the advanced extensions group as these have four operands and are not as likely to see frequent usage.