### PR TITLE
Feature/relative perf

### DIFF
--- a/source/junk/build.sh
+++ b/source/junk/build.sh
@@ -5,3 +5,5 @@ g++ -O3 -funroll-loops -fwhole-program card_raytracer.cpp -o card_raytracer
 g++ -O3 -funroll-loops -fwhole-program card_raytracer.cpp -S
 g++ -O3 -funroll-loops -fwhole-program card_raytracer_vec.cpp -o card_raytracer_vec
 g++ -O3 -funroll-loops -fwhole-program card_raytracer_vec.cpp -S
+gcc -O3 -funroll-loops -fwhole-program mandelbrot.c -o mandelbrot
+gcc -O3 -funroll-loops -fwhole-program mandelbrot.c -S

--- a/source/junk/card_raytracer.cpp
+++ b/source/junk/card_raytracer.cpp
@@ -34,6 +34,29 @@ struct vec3 {
 
 };
 
+const vec3 camera_dir(
+  -6.0, -16.0, 0.0
+);
+
+const vec3 focal_point(
+  17.0, 16.0, 8.0
+);
+
+const vec3 normal_up(
+  0.0, 0.0, 1.0
+);
+
+const vec3 sky_rgb(
+  0.7, 0.6, 1.0
+);
+
+const vec3 floor_red_rgb(
+  3.0, 1.0, 1.0
+);
+
+const vec3 floor_white_rgb(
+  3.0, 1.0, 1.0
+);
 ///////////////////////////////////////////////////////////////////////////////
 
 #ifdef NO_PASS_BY_REF
@@ -130,7 +153,7 @@ int32 trace(cvr3 origin, cvr3 direction, float32& distance, vec3& normal) {
   // Check if trace maybe hits floor
   if (0.01 < p) {
     distance = p,
-    normal   = vec3(0.0, 0.0, 1.0),
+    normal   = normal_up,
     material = 1;
   }
 
@@ -161,6 +184,7 @@ int32 trace(cvr3 origin, cvr3 direction, float32& distance, vec3& normal) {
       }
     }
   }
+
   return material;
 }
 
@@ -180,7 +204,7 @@ vec3 sample(cvr3 origin, cvr3 direction) {
     gradient *= gradient;
     gradient *= gradient;
     return vec3_scale(
-      vec3(0.7, 0.6, 1.0), // Blueish sky colour
+      sky_rgb, // Blueish sky colour
       gradient
     );
   }
@@ -222,8 +246,8 @@ vec3 sample(cvr3 origin, cvr3 direction) {
       (
         // Compute check colour based on the position
         (int32) (ceil(intersection.x) + ceil(intersection.y)) & 1 ?
-        vec3(3.0, 1.0, 1.0) : // red
-        vec3(3.0, 3.0, 3.0)   // white
+        floor_red_rgb : // red
+        floor_white_rgb   // white
       ),
       (lambertian * 0.2 + 0.1)
     );
@@ -252,13 +276,13 @@ int32 main() {
   // camera direction vectors
   vec3
     camera_forward = vec3_normalize( // Unit forwards
-      vec3(-6.0, -16.0, 0.0)
+      camera_dir
     ),
 
     camera_up = vec3_scale( // Unit up - Z is up in this system
       vec3_normalize(
         vec3_cross(
-          vec3(0.0, 0.0, 1.0),
+          normal_up,
           camera_forward
         )
       ),
@@ -291,7 +315,7 @@ int32 main() {
 
         // Random delta to be added for depth of field effects
         vec3 delta = vec3_add(
-          vec3_scale(camera_up, (frand() - 0.5) * 99.0),
+          vec3_scale(camera_up,    (frand() - 0.5) * 99.0),
           vec3_scale(camera_right, (frand() - 0.5) * 99.0)
         );
 
@@ -300,7 +324,7 @@ int32 main() {
           vec3_scale(
             sample(
               vec3_add(
-                vec3(17.0, 16.0, 8.0), // Focal point
+                focal_point,
                 delta
               ),
               vec3_normalize(

--- a/source/junk/mandelbrot.c
+++ b/source/junk/mandelbrot.c
@@ -1,0 +1,48 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+int iSize       = 1024;
+int iMaxIters   = 512;
+float fBailout  = 16.0;
+float fYMin     = -1.25;
+float fYMax     = 1.25;
+float fXMax     = 0.75;
+
+int main() {
+  float fYTot = fYMax - fYMin;
+  float fXMin = fXMax - fYTot;
+  float fStep = fYTot / iSize;
+  unsigned char* aPixels = (unsigned char*) malloc(iSize * iSize);
+
+  if (aPixels) {
+    FILE* f;
+    int iPix = 0;
+    float fCY   = fYMax;
+    for (int y = 0; y<iSize; y++, fCY -= fStep) {
+      float fCX = fXMin;
+      for (int x = 0; x<iSize; x++, fCX += fStep) {
+        int i   = iMaxIters;
+        float fZX = fCX;
+        float fZY = fCY;
+        float fTest, fZX2, fZY2, fNewZX, fNewZY;
+        do {
+          fZX2   = fZX * fZX;
+          fZY2   = fZY * fZY;
+          fTest  = fZX2 + fZY2;
+          fNewZX = fZX2 - fZY2 + fCX;
+          fNewZY = 2.0 * fZX * fZY + fCY;
+          fZY    = fNewZY;
+          fZX    = fNewZX;
+        } while (--i && fTest < fBailout);
+        aPixels[iPix++] = (i * i) & 0xFF;
+      }
+    }
+
+    f = fopen("c_out.ppm", "wb");
+    fprintf(f, "P5\n%d\n%d\n255\n", iSize, iSize);
+    fwrite(aPixels, 1, iSize * iSize, f);
+    fclose(f);
+    free(aPixels);
+  }
+  return 0;
+}

--- a/source/junk/mandelbrot.php
+++ b/source/junk/mandelbrot.php
@@ -1,8 +1,8 @@
 <?php
 
-$iSize     = 512;
-$iMaxIters = 256;
-$fBailout  = 4.0;
+$iSize     = 1024;
+$iMaxIters = 512;
+$fBailout  = 16.0;
 
 $fYMin = -1.25;
 $fYMax = 1.25;
@@ -35,7 +35,7 @@ for ($y = 0; $y<$iSize; $y++, $fCY -= $fStep) {
   }
 }
 
-$f = fopen('out.ppm', 'wb');
+$f = fopen("php_out.ppm", "wb");
 fprintf($f, "P5\n%d\n%d\n255\n", $iSize,$iSize);
 $sBuff = '';
 foreach ($aPixels as $iPix) {

--- a/source/junk/mandelbrot.php
+++ b/source/junk/mandelbrot.php
@@ -1,0 +1,45 @@
+<?php
+
+$iSize     = 512;
+$iMaxIters = 256;
+$fBailout  = 4.0;
+
+$fYMin = -1.25;
+$fYMax = 1.25;
+$fYTot = $fYMax - $fYMin;
+$fXMax = 0.75;
+$fXMin = $fXMax - $fYTot;
+$fStep = $fYTot / $iSize;
+
+$aPixels = new SPLFixedArray($iSize * $iSize);
+
+$iPix = 0;
+$fCY   = $fYMax;
+for ($y = 0; $y<$iSize; $y++, $fCY -= $fStep) {
+  $fCX = $fXMin;
+  for ($x = 0; $x<$iSize; $x++, $fCX += $fStep) {
+    $i   = $iMaxIters;
+    $fZX = $fCX;
+    $fZY = $fCY;
+    $i   = $iMaxIters;
+    do {
+      $fZX2   = $fZX * $fZX;
+      $fZY2   = $fZY * $fZY;
+      $fTest  = $fZX2 + $fZY2;
+      $fNewZX = $fZX2 - $fZY2 + $fCX;
+      $fNewZY = 2 * $fZX * $fZY + $fCY;
+      $fZY    = $fNewZY;
+      $fZX    = $fNewZX;
+    } while (--$i && $fTest < $fBailout);
+    $aPixels[$iPix++] = ($i*$i)&0xFF;
+  }
+}
+
+$f = fopen('out.ppm', 'wb');
+fprintf($f, "P5\n%d\n%d\n255\n", $iSize,$iSize);
+$sBuff = '';
+foreach ($aPixels as $iPix) {
+  $sBuff .= chr($iPix);
+}
+fwrite($f, $sBuff);
+fclose($f);

--- a/source/vm_core.cpp
+++ b/source/vm_core.cpp
@@ -148,10 +148,10 @@ void Interpreter::setDataSymbolTable(void** symbol, uint32 count) {
 
 void Interpreter::execute() {
   MilliClock total;
-  int numStatements = 0;
-  totalTime         = 0;
-  nativeTime        = 0;
-  status            = VMDefs::RUNNING;
+  uint64 numStatements = 0;
+  totalTime            = 0;
+  nativeTime           = 0;
+  status               = VMDefs::RUNNING;
 
 #if _VM_INTERPRETER == _VM_INTERPRETER_FUNC_TABLE
   #include "include/vm_interpreter_func_table_impl.hpp"
@@ -162,7 +162,7 @@ void Interpreter::execute() {
 #endif
 
   totalTime = total.elapsedFrac();
-  debuglog(LOG_INFO, "Executed %d statements\n", numStatements);
+  debuglog(LOG_INFO, "Executed %" FU64 " statements\n", numStatements);
   float64 virtualTime = totalTime - nativeTime;
   float64 mips        = (0.001*numStatements)/virtualTime;
   debuglog(

--- a/source/vmprogram.cpp
+++ b/source/vmprogram.cpp
@@ -96,8 +96,8 @@ uint16 mockCodeSegment[] = {
   // r9 = iStep (1)
 
   _save       (_mr0|_mr2)                // 2 : save pixel base address
-  _ld_32_f32  (4.0f, _r4)                // 3 : bailout = 4.0
-  _ld_16_i32  (255,  _r9)                // 2 : max iters
+  _ld_32_f32  (16.0f, _r4)                // 3 : bailout = 4.0
+  _ld_16_i32  (512,  _r9)                // 2 : max iters
 
   // y loop
   _ldq        (0,    _r8)                // 1 : x = 0
@@ -166,8 +166,8 @@ uint16 mockCodeSegment[] = {
   _ret,
 
   // Offset 62 : @main
-  _ld_16_i16         (512, _r1)      // 62
-  _ld_16_i16         (512, _r2)      // 64
+  _ld_16_i16         (1024, _r1)      // 62
+  _ld_16_i16         (1024, _r2)      // 64
   _calln_unresolved  (@allocBuff)    // 66 : insert @allocBuff -> 67
   _ld_32_f32         (-1.25f, _r3)   // 68
   _ld_32_f32         (1.25f, _r4)    // 71


### PR DESCRIPTION
Reworked mandelbrot test to compute 1024x1024 with max 512 iterations and a bailout of 16 in order to pessimise the test for meaningful performance measurements.
- Provided vanilla C and PHP implementations based on identical algorithm for comparison.
- Some small changes to the deobfuscated aek raytracer as a prelude to porting.