### PR TITLE
Tidying of perf branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+source/.kdev*
+source/source.kdev4
+source/junk/*.pnm
+source/junk/*.ppm
+source/junk/*.pgm
+source/junk/*.s
+source/junk/card_original
+source/junk/card_raytracer
+source/junk/card_raytracer_noref
+source/junk/card_raytracer_vec
+source/junk/mandelbrot
+source/junk/xhprof
+source/junk/profiling.php

--- a/source/junk/mandelbrot.c
+++ b/source/junk/mandelbrot.c
@@ -2,7 +2,7 @@
 #include <stdlib.h>
 
 int iSize       = 1024;
-int iMaxIters   = 512;
+int iMaxIters   = 256;
 float fBailout  = 16.0;
 float fYMin     = -1.25;
 float fYMax     = 1.25;

--- a/source/junk/mandelbrot.php
+++ b/source/junk/mandelbrot.php
@@ -1,7 +1,7 @@
 <?php
 
 $iSize     = 1024;
-$iMaxIters = 512;
+$iMaxIters = 256;
 $fBailout  = 16.0;
 
 $fYMin = -1.25;
@@ -18,7 +18,6 @@ $fCY   = $fYMax;
 for ($y = 0; $y<$iSize; $y++, $fCY -= $fStep) {
   $fCX = $fXMin;
   for ($x = 0; $x<$iSize; $x++, $fCX += $fStep) {
-    $i   = $iMaxIters;
     $fZX = $fCX;
     $fZY = $fCY;
     $i   = $iMaxIters;

--- a/source/vm_core.cpp
+++ b/source/vm_core.cpp
@@ -148,7 +148,13 @@ void Interpreter::setDataSymbolTable(void** symbol, uint32 count) {
 
 void Interpreter::execute() {
   MilliClock total;
+#if X_PTRSIZE == XA_PTRSIZE64
   uint64 numStatements = 0;
+  #define FCNT FU64
+#else
+  uint32 numStatements = 0;
+  #define FCNT FU32
+#endif
   totalTime            = 0;
   nativeTime           = 0;
   status               = VMDefs::RUNNING;
@@ -162,7 +168,7 @@ void Interpreter::execute() {
 #endif
 
   totalTime = total.elapsedFrac();
-  debuglog(LOG_INFO, "Executed %" FU64 " statements\n", numStatements);
+  debuglog(LOG_INFO, "Executed %" FCNT " statements\n", numStatements);
   float64 virtualTime = totalTime - nativeTime;
   float64 mips        = (0.001*numStatements)/virtualTime;
   debuglog(

--- a/source/vmprogram.cpp
+++ b/source/vmprogram.cpp
@@ -97,7 +97,7 @@ uint16 mockCodeSegment[] = {
 
   _save       (_mr0|_mr2)                // 2 : save pixel base address
   _ld_32_f32  (16.0f, _r4)                // 3 : bailout = 4.0
-  _ld_16_i32  (512,  _r9)                // 2 : max iters
+  _ld_16_i32  (256,  _r9)                // 2 : max iters
 
   // y loop
   _ldq        (0,    _r8)                // 1 : x = 0

--- a/source/vmprogram.cpp
+++ b/source/vmprogram.cpp
@@ -88,7 +88,7 @@ uint16 mockCodeSegment[] = {
   // r1 = width in pixels
   // r2 = height in pixels
   // r3 = cY (float pos, starting at yMin)
-  // r4 = 4.0 (bailout)
+  // r4 = 16.0 (bailout)
   // r5 = xMin (float)
   // r6 = cX (float pos, starting at xMin)
   // r7 = fStep
@@ -96,7 +96,7 @@ uint16 mockCodeSegment[] = {
   // r9 = iStep (1)
 
   _save       (_mr0|_mr2)                // 2 : save pixel base address
-  _ld_32_f32  (16.0f, _r4)                // 3 : bailout = 4.0
+  _ld_32_f32  (16.0f, _r4)               // 3 : bailout = 16.0
   _ld_16_i32  (256,  _r9)                // 2 : max iters
 
   // y loop


### PR DESCRIPTION
Reworked mandelbrot test to compute 1024x1024 with max 512 iterations and a bailout of 16 in order to pessimise the test for meaningful performance measurements.
- Provided vanilla C and PHP implementations based on identical algorithm for comparison.
- Some small changes to the deobfuscated aek raytracer as a prelude to porting.